### PR TITLE
Inner Attributed types now supported

### DIFF
--- a/src/argument.rs
+++ b/src/argument.rs
@@ -20,14 +20,14 @@ impl Parse for Argument {
     ));
 }
 
-/// Parses `[attributes]? optional? type identifier ( = default )?`
+/// Parses `[attributes]? optional? attributedtype identifier ( = default )?`
 ///
 /// Note: `= default` is only allowed if `optional` is present
 #[derive(Debug, PartialEq)]
 pub struct SingleArgument {
     pub attributes: Option<ExtendedAttributeList>,
     pub optional: Option<term!(optional)>,
-    pub type_: Type,
+    pub type_: AttributedType,
     pub identifier: Identifier,
     pub default: Option<Default>
 }
@@ -36,7 +36,7 @@ impl Parse for SingleArgument {
     named!(parse -> Self, do_parse!(
         attributes: weedle!(Option<ExtendedAttributeList>) >>
         optional: weedle!(Option<term!(optional)>) >>
-        type_: weedle!(Type) >>
+        type_: weedle!(AttributedType) >>
         identifier: weedle!(Identifier) >>
         default: opt_flat!(cond_reduce!(optional.is_some(), weedle!(Option<Default>))) >>
         (SingleArgument { attributes, optional, type_, identifier, default })

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -72,14 +72,14 @@ impl Parse for ConstMember {
     ));
 }
 
-/// Parses `[attributes]? (stringifier|inherit|static)? readonly? attribute type identifier;`
+/// Parses `[attributes]? (stringifier|inherit|static)? readonly? attribute attributedtype identifier;`
 #[derive(Debug, PartialEq)]
 pub struct AttributeInterfaceMember {
     pub attributes: Option<ExtendedAttributeList>,
     pub modifier: Option<StringifierOrInheritOrStatic>,
     pub readonly: Option<term!(readonly)>,
     pub attribute: term!(attribute),
-    pub type_: Type,
+    pub type_: AttributedType,
     pub identifier: Identifier,
     pub semi_colon: term!(;)
 }
@@ -90,7 +90,7 @@ impl Parse for AttributeInterfaceMember {
         modifier: weedle!(Option<StringifierOrInheritOrStatic>) >>
         readonly: weedle!(Option<term!(readonly)>) >>
         attribute: weedle!(term!(attribute)) >>
-        type_: weedle!(Type) >>
+        type_: weedle!(AttributedType) >>
         identifier: weedle!(Identifier) >>
         semi_colon: weedle!(term!(;)) >>
         (AttributeInterfaceMember { attributes, modifier, readonly, attribute, type_, identifier, semi_colon })
@@ -140,7 +140,7 @@ impl Parse for Special {
     ));
 }
 
-/// Parses an iterable declaration `[attributes]? (iterable<type> | iterable<type, type>) ;`
+/// Parses an iterable declaration `[attributes]? (iterable<attributedtype> | iterable<attributedtype, attributedtype>) ;`
 #[derive(Debug, PartialEq)]
 pub enum IterableInterfaceMember {
     Single(SingleTypedIterable),
@@ -154,12 +154,12 @@ impl Parse for IterableInterfaceMember {
     ));
 }
 
-/// Parses an iterable declaration `[attributes]? iterable<type>;`
+/// Parses an iterable declaration `[attributes]? iterable<attributedtype>;`
 #[derive(Debug, PartialEq)]
 pub struct SingleTypedIterable {
     pub attributes: Option<ExtendedAttributeList>,
     pub iterable: term!(iterable),
-    pub generics: Generics<Type>,
+    pub generics: Generics<AttributedType>,
     pub semi_colon: term!(;)
 }
 
@@ -167,18 +167,18 @@ impl Parse for SingleTypedIterable {
     named!(parse -> Self, do_parse!(
         attributes: weedle!(Option<ExtendedAttributeList>) >>
         iterable: weedle!(term!(iterable)) >>
-        generics: weedle!(Generics<Type>) >>
+        generics: weedle!(Generics<AttributedType>) >>
         semi_colon: weedle!(term!(;)) >>
         (SingleTypedIterable { attributes, iterable, generics, semi_colon })
     ));
 }
 
-/// Parses an iterable declaration `[attributes]? iterable<type, type>;`
+/// Parses an iterable declaration `[attributes]? iterable<attributedtype, attributedtype>;`
 #[derive(Debug, PartialEq)]
 pub struct DoubleTypedIterable {
     pub attributes: Option<ExtendedAttributeList>,
     pub iterable: term!(iterable),
-    pub generics: Generics<(Type, term!(,), Type)>,
+    pub generics: Generics<(AttributedType, term!(,), AttributedType)>,
     pub semi_colon: term!(;)
 }
 
@@ -186,19 +186,19 @@ impl Parse for DoubleTypedIterable {
     named!(parse -> Self, do_parse!(
         attributes: weedle!(Option<ExtendedAttributeList>) >>
         iterable: weedle!(term!(iterable)) >>
-        generics: weedle!(Generics<(Type, term!(,), Type)>) >>
+        generics: weedle!(Generics<(AttributedType, term!(,), AttributedType)>) >>
         semi_colon: weedle!(term!(;)) >>
         (DoubleTypedIterable { attributes, iterable, generics, semi_colon })
     ));
 }
 
-/// Parses an maplike declaration `[attributes]? readonly? maplike<type, type>;`
+/// Parses an maplike declaration `[attributes]? readonly? maplike<attributedtype, attributedtype>;`
 #[derive(Debug, PartialEq)]
 pub struct MaplikeInterfaceMember {
     pub attributes: Option<ExtendedAttributeList>,
     pub readonly: Option<term!(readonly)>,
     pub maplike: term!(maplike),
-    pub generics: Generics<(Type, term!(,), Type)>,
+    pub generics: Generics<(AttributedType, term!(,), AttributedType)>,
     pub semi_colon: term!(;)
 }
 
@@ -207,19 +207,19 @@ impl Parse for MaplikeInterfaceMember {
         attributes: weedle!(Option<ExtendedAttributeList>) >>
         readonly: weedle!(Option<term!(readonly)>) >>
         maplike: weedle!(term!(maplike)) >>
-        generics: weedle!(Generics<(Type, term!(,), Type)>) >>
+        generics: weedle!(Generics<(AttributedType, term!(,), AttributedType)>) >>
         semi_colon: weedle!(term!(;)) >>
         (MaplikeInterfaceMember { attributes, readonly, maplike, generics, semi_colon })
     ));
 }
 
-/// Parses an setlike declaration `[attributes]? readonly? setlike<type>;`
+/// Parses an setlike declaration `[attributes]? readonly? setlike<attributedtype>;`
 #[derive(Debug, PartialEq)]
 pub struct SetlikeInterfaceMember {
     pub attributes: Option<ExtendedAttributeList>,
     pub readonly: Option<term!(readonly)>,
     pub setlike: term!(setlike),
-    pub generics: Generics<Type>,
+    pub generics: Generics<AttributedType>,
     pub semi_colon: term!(;)
 }
 
@@ -228,7 +228,7 @@ impl Parse for SetlikeInterfaceMember {
         attributes: weedle!(Option<ExtendedAttributeList>) >>
         readonly: weedle!(Option<term!(readonly)>) >>
         setlike: weedle!(term!(setlike)) >>
-        generics: weedle!(Generics<Type>) >>
+        generics: weedle!(Generics<AttributedType>) >>
         semi_colon: weedle!(term!(;)) >>
         (SetlikeInterfaceMember { attributes, readonly, setlike, generics, semi_colon })
     ));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,24 +17,9 @@
 //! ```
 //!
 //! Note:
-//! This parser tries to follow the grammar given at [WebIDL](https://heycam.github.io/webidl)
-//! but is not one-to-one. Makes necessary assumptions as per the real world WebIDL definitions.
+//! This parser follows the grammar given at [WebIDL](https://heycam.github.io/webidl).
 //!
-//! First, the parser only allows stricter attributes defined in the grammar.
-//!
-//! Second, No inner `[attributes]` are allowed. For example the following is allowed:
-//!
-//! `[attributes] attribute Type identifier` instead of
-//!
-//! `[attributes] attribute AttributedType AttributeName`
-//!
-//! where `AttributedType` is `[attribute] Type` and `AttributeName` is one of
-//! `required|identifier`.
-//!
-//! Using attributes within declaration is redundant. Only preceding attributes to declarations &
-//! arguments are considered.
-//!
-//! Also `identifier` takes in any valid value regardless of whether it is keyword or not.
+//! If any flaws found when parsing string with a valid grammar, create an issue.
 
 #[macro_use]
 extern crate lazy_static;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,12 +412,12 @@ impl Parse for EnumDefinition {
     ));
 }
 
-/// Parses `[attributes]? typedef type identifier;`
+/// Parses `[attributes]? typedef attributedtype identifier;`
 #[derive(Debug, PartialEq)]
 pub struct TypedefDefinition {
     pub attributes: Option<ExtendedAttributeList>,
     pub typedef: term!(typedef),
-    pub type_: Type,
+    pub type_: AttributedType,
     pub identifier: Identifier,
     pub semi_colon: term!(;)
 }
@@ -426,7 +426,7 @@ impl Parse for TypedefDefinition {
     named!(parse -> Self, do_parse!(
         attributes: weedle!(Option<ExtendedAttributeList>) >>
         typedef: weedle!(term!(typedef)) >>
-        type_: weedle!(Type) >>
+        type_: weedle!(AttributedType) >>
         identifier: weedle!(Identifier) >>
         semi_colon: weedle!(term!(;)) >>
         (TypedefDefinition { attributes, typedef, type_, identifier, semi_colon })

--- a/src/mixin.rs
+++ b/src/mixin.rs
@@ -51,14 +51,14 @@ impl Parse for OperationMixinMember {
     ));
 }
 
-/// Parses `[attributes]? stringifier? readonly? attribute type identifier;`
+/// Parses `[attributes]? stringifier? readonly? attribute attributedtype identifier;`
 #[derive(Debug, PartialEq)]
 pub struct AttributeMixinMember {
     pub attributes: Option<ExtendedAttributeList>,
     pub stringifier: Option<term!(stringifier)>,
     pub readonly: Option<term!(readonly)>,
     pub attribute: term!(attribute),
-    pub type_: Type,
+    pub type_: AttributedType,
     pub identifier: Identifier,
     pub semi_colon: term!(;)
 }
@@ -69,7 +69,7 @@ impl Parse for AttributeMixinMember {
         stringifier: weedle!(Option<term!(stringifier)>) >>
         readonly: weedle!(Option<term!(readonly)>) >>
         attribute: weedle!(term!(attribute)) >>
-        type_: weedle!(Type) >>
+        type_: weedle!(AttributedType) >>
         identifier: weedle!(Identifier) >>
         semi_colon: weedle!(term!(;)) >>
         (AttributeMixinMember { attributes, stringifier, readonly, attribute, type_, identifier, semi_colon })

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -44,13 +44,13 @@ impl Parse for OperationNamespaceMember {
     ));
 }
 
-/// Parses `[attribute]? readonly attribute type identifier;`
+/// Parses `[attribute]? readonly attributetype type identifier;`
 #[derive(Debug, PartialEq)]
 pub struct AttributeNamespaceMember {
     pub attributes: Option<ExtendedAttributeList>,
     pub readonly: term!(readonly),
     pub attribute: term!(attribute),
-    pub type_: Type,
+    pub type_: AttributedType,
     pub identifier: Identifier,
     pub semi_colon: term!(;)
 }
@@ -60,7 +60,7 @@ impl Parse for AttributeNamespaceMember {
         attributes: weedle!(Option<ExtendedAttributeList>) >>
         readonly: weedle!(term!(readonly)) >>
         attribute: weedle!(term!(attribute)) >>
-        type_: weedle!(Type) >>
+        type_: weedle!(AttributedType) >>
         identifier: weedle!(Identifier) >>
         semi_colon: weedle!(term!(;)) >>
         (AttributeNamespaceMember { attributes, readonly, attribute, type_, identifier, semi_colon })

--- a/src/types.rs
+++ b/src/types.rs
@@ -594,4 +594,10 @@ mod test {
             Union == "(short or float)"
         }
     );
+
+    test!(should_parse_attributed_type { "[Named] short" =>
+        "";
+        AttributedType;
+        attributes.is_some();
+    });
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,7 @@
 use Parse;
 use common::*;
 use term;
+use attribute::*;
 
 /// Parses either single type or a union type
 #[derive(Debug, PartialEq)]
@@ -394,6 +395,21 @@ impl Parse for ReturnType {
     named!(parse -> Self, alt_complete!(
         weedle!(term!(void)) => {|inner| ReturnType::Void(inner)} |
         weedle!(Type) => {|inner| ReturnType::Type(inner)}
+    ));
+}
+
+/// Parses `[attributes]? type`
+#[derive(Debug, PartialEq)]
+pub struct AttributedType {
+    pub attributes: Option<ExtendedAttributeList>,
+    pub type_: Type
+}
+
+impl Parse for AttributedType {
+    named!(parse -> Self, do_parse!(
+        attributes: weedle!(Option<ExtendedAttributeList>) >>
+        type_: weedle!(Type) >>
+        (AttributedType { attributes, type_ })
     ));
 }
 


### PR DESCRIPTION
Previously, only the top level types on declarations & before arguments were supported. I was wrong in thinking it was not used in real world scenarios & it being redudant. 