### PR TITLE
Refactor and zero-copy pervasively

### DIFF
--- a/src/argument.rs
+++ b/src/argument.rs
@@ -3,27 +3,30 @@ use common::{Default, Identifier, Punctuated};
 use types::{AttributedType, Type};
 
 /// Parses a list of argument. Ex: `double v1, double v2, double v3, optional double alpha`
-pub type ArgumentList = Punctuated<Argument, term!(,)>;
+pub type ArgumentList<'a> = Punctuated<Argument<'a>, term!(,)>;
 
 ast_types! {
     /// Parses an argument. Ex: `double v1|double... v1s`
-    enum Argument {
+    enum Argument<'a> {
         /// Parses `[attributes]? optional? attributedtype identifier ( = default )?`
         ///
         /// Note: `= default` is only allowed if `optional` is present
-        Single(struct SingleArgument {
-            attributes: Option<ExtendedAttributeList>,
+        Single(struct SingleArgument<'a> {
+            attributes: Option<ExtendedAttributeList<'a>>,
             optional: Option<term!(optional)>,
-            type_: AttributedType,
-            identifier: Identifier,
-            default: Option<Default> = map!(cond!(optional.is_some(), weedle!(Option<Default>)), |default| default.unwrap_or(None)),
+            type_: AttributedType<'a>,
+            identifier: Identifier<'a>,
+            default: Option<Default<'a>> = map!(
+                cond!(optional.is_some(), weedle!(Option<Default<'a>>)),
+                |default| default.unwrap_or(None)
+            ),
         }),
         /// Parses `[attributes]? type... identifier`
-        Variadic(struct VariadicArgument {
-            attributes: Option<ExtendedAttributeList>,
-            type_: Type,
+        Variadic(struct VariadicArgument<'a> {
+            attributes: Option<ExtendedAttributeList<'a>>,
+            type_: Type<'a>,
             ellipsis: term!(...),
-            identifier: Identifier,
+            identifier: Identifier<'a>,
         }),
     }
 }
@@ -67,7 +70,7 @@ mod test {
         identifier.0 == "a";
         default == Some(Default {
             assign: term!(=),
-            value: DefaultValue::Integer(IntegerLit::Dec(DecLit("5".to_string()))),
+            value: DefaultValue::Integer(IntegerLit::Dec(DecLit("5"))),
         });
     });
 }

--- a/src/argument.rs
+++ b/src/argument.rs
@@ -1,77 +1,45 @@
-use types::*;
-use Parse;
-use common::*;
-use attribute::*;
+use attribute::ExtendedAttributeList;
+use common::{Default, Identifier, Punctuated};
+use types::{AttributedType, Type};
 
 /// Parses a list of argument. Ex: `double v1, double v2, double v3, optional double alpha`
 pub type ArgumentList = Punctuated<Argument, term!(,)>;
 
-/// Parses an argument. Ex: `double v1|double... v1s`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub enum Argument {
-    Single(SingleArgument),
-    Variadic(VariadicArgument)
-}
-
-impl Parse for Argument {
-    named!(parse -> Self, alt!(
-        weedle!(SingleArgument) => {|inner| Argument::Single(inner)} |
-        weedle!(VariadicArgument) => {|inner| Argument::Variadic(inner)}
-    ));
-}
-
-/// Parses `[attributes]? optional? attributedtype identifier ( = default )?`
-///
-/// Note: `= default` is only allowed if `optional` is present
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct SingleArgument {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub optional: Option<term!(optional)>,
-    pub type_: AttributedType,
-    pub identifier: Identifier,
-    pub default: Option<Default>
-}
-
-impl Parse for SingleArgument {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        optional: weedle!(Option<term!(optional)>) >>
-        type_: weedle!(AttributedType) >>
-        identifier: weedle!(Identifier) >>
-        default: opt_flat!(cond_reduce!(optional.is_some(), weedle!(Option<Default>))) >>
-        (SingleArgument { attributes, optional, type_, identifier, default })
-    ));
-}
-
-/// Parses `[attributes]? type... identifier`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct VariadicArgument {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub type_: Type,
-    pub ellipsis: term!(...),
-    pub identifier: Identifier
-}
-
-impl Parse for VariadicArgument {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        type_: weedle!(Type) >>
-        ellipsis: weedle!(term!(...)) >>
-        identifier: weedle!(Identifier) >>
-        (VariadicArgument { attributes, type_, ellipsis, identifier })
-    ));
+ast_types! {
+    /// Parses an argument. Ex: `double v1|double... v1s`
+    enum Argument {
+        /// Parses `[attributes]? optional? attributedtype identifier ( = default )?`
+        ///
+        /// Note: `= default` is only allowed if `optional` is present
+        Single(struct SingleArgument {
+            attributes: Option<ExtendedAttributeList>,
+            optional: Option<term!(optional)>,
+            type_: AttributedType,
+            identifier: Identifier,
+            default: Option<Default> = map!(cond!(optional.is_some(), weedle!(Option<Default>)), |default| default.unwrap_or(None)),
+        }),
+        /// Parses `[attributes]? type... identifier`
+        Variadic(struct VariadicArgument {
+            attributes: Option<ExtendedAttributeList>,
+            type_: Type,
+            ellipsis: term!(...),
+            identifier: Identifier,
+        }),
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use literal::{DecLit, DefaultValue, IntegerLit};
+    use Parse;
 
-    test!(should_parse_single_argument { "optional short a" =>
+    test!(should_parse_single_argument { "short a" =>
         "";
         SingleArgument;
         attributes.is_none();
-        optional.is_some();
-        identifier.name == "a";
+        optional.is_none();
+        identifier.0 == "a";
         default.is_none();
     });
 
@@ -79,6 +47,27 @@ mod test {
         "";
         VariadicArgument;
         attributes.is_none();
-        identifier.name == "a";
+        identifier.0 == "a";
+    });
+
+    test!(should_parse_optional_single_argument { "optional short a" =>
+        "";
+        SingleArgument;
+        attributes.is_none();
+        optional.is_some();
+        identifier.0 == "a";
+        default.is_none();
+    });
+
+    test!(should_parse_optional_single_argument_with_default { "optional short a = 5" =>
+        "";
+        SingleArgument;
+        attributes.is_none();
+        optional.is_some();
+        identifier.0 == "a";
+        default == Some(Default {
+            assign: term!(=),
+            value: DefaultValue::Integer(IntegerLit::Dec(DecLit("5".to_string()))),
+        });
     });
 }

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -2,48 +2,50 @@ use argument::ArgumentList;
 use common::{Braced, Bracketed, Identifier, Punctuated};
 
 /// Parses a list of attributes. Ex: `[ attribute1, attribute2 ]`
-pub type ExtendedAttributeList = Bracketed<Punctuated<ExtendedAttribute, term!(,)>>;
+pub type ExtendedAttributeList<'a> = Bracketed<Punctuated<ExtendedAttribute<'a>, term!(,)>>;
 
 /// Matches comma separated identifier list
-pub type IdentifierList = Punctuated<Identifier, term!(,)>;
+pub type IdentifierList<'a> = Punctuated<Identifier<'a>, term!(,)>;
 
 ast_types! {
     /// Parses on of the forms of attribute
-    enum ExtendedAttribute {
+    enum ExtendedAttribute<'a> {
         /// Parses an argument list. Ex: `Constructor((double x, double y))`
         ///
         /// (( )) means ( ) chars
-        ArgList(struct ExtendedAttributeArgList {
-            identifier: Identifier,
-            args: Braced<ArgumentList>,
+        ArgList(struct ExtendedAttributeArgList<'a> {
+            identifier: Identifier<'a>,
+            args: Braced<ArgumentList<'a>>,
         }),
         /// Parses a named argument list. Ex: `NamedConstructor=Image((DOMString src))`
         ///
         /// (( )) means ( ) chars
-        NamedArgList(struct ExtendedAttributeNamedArgList {
-            lhs_identifier: Identifier,
+        NamedArgList(struct ExtendedAttributeNamedArgList<'a> {
+            lhs_identifier: Identifier<'a>,
             assign: term!(=),
-            rhs_identifier: Identifier,
-            args: Braced<ArgumentList>,
+            rhs_identifier: Identifier<'a>,
+            args: Braced<ArgumentList<'a>>,
 
         }),
         /// Parses an identifier list. Ex: `Exposed=((Window,Worker))`
         ///
         /// (( )) means ( ) chars
-        IdentList(struct ExtendedAttributeIdentList {
-            identifier: Identifier,
+        IdentList(struct ExtendedAttributeIdentList<'a> {
+            identifier: Identifier<'a>,
             assign: term!(=),
-            list: Braced<IdentifierList>,
+            list: Braced<IdentifierList<'a>>,
         }),
         /// Parses an attribute with an identifier. Ex: `PutForwards=name`
-        Ident(struct ExtendedAttributeIdent {
-            lhs_identifier: Identifier,
+        #[derive(Copy)]
+        Ident(struct ExtendedAttributeIdent<'a> {
+            lhs_identifier: Identifier<'a>,
             assign: term!(=),
-            rhs_identifier: Identifier,
+            rhs_identifier: Identifier<'a>,
         }),
         /// Parses a plain attribute. Ex: `Replaceable`
-        NoArgs(struct ExtendedAttributeNoArgs(
-            Identifier,
+        #[derive(Copy)]
+        NoArgs(struct ExtendedAttributeNoArgs<'a>(
+            Identifier<'a>,
         )),
     }
 }
@@ -55,7 +57,7 @@ mod test {
 
     test!(should_parse_attribute_no_args { "Replaceable" =>
         "";
-        ExtendedAttributeNoArgs => ExtendedAttributeNoArgs(Identifier("Replaceable".to_string()))
+        ExtendedAttributeNoArgs => ExtendedAttributeNoArgs(Identifier("Replaceable"))
     });
 
     test!(should_parse_attribute_arg_list { "Constructor(double x, double y)" =>

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -1,156 +1,89 @@
-use Parse;
-use common::*;
-use argument::*;
+use argument::ArgumentList;
+use common::{Braced, Bracketed, Identifier, Punctuated};
 
 /// Parses a list of attributes. Ex: `[ attribute1, attribute2 ]`
 pub type ExtendedAttributeList = Bracketed<Punctuated<ExtendedAttribute, term!(,)>>;
 
-/// Parses on of the forms of attribute
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub enum ExtendedAttribute {
-    ArgList(ExtendedAttributeArgList),
-    NamedArgList(ExtendedAttributeNamedArgList),
-    IdentList(ExtendedAttributeIdentList),
-    Ident(ExtendedAttributeIdent),
-    NoArgs(ExtendedAttributeNoArgs),
-}
-
-impl Parse for ExtendedAttribute {
-    named!(parse -> Self, alt!(
-        weedle!(ExtendedAttributeArgList) => {|inner| ExtendedAttribute::ArgList(inner)} |
-        weedle!(ExtendedAttributeNamedArgList) => {|inner| ExtendedAttribute::NamedArgList(inner)} |
-        weedle!(ExtendedAttributeIdentList) => {|inner| ExtendedAttribute::IdentList(inner)} |
-        weedle!(ExtendedAttributeIdent) => {|inner| ExtendedAttribute::Ident(inner)} |
-        weedle!(ExtendedAttributeNoArgs) => {|inner| ExtendedAttribute::NoArgs(inner)}
-    ));
-}
-
-/// Parses a named argument list. Ex: `NamedConstructor=Image((DOMString src))`
-///
-/// (( )) means ( ) chars
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct ExtendedAttributeNamedArgList {
-    pub lhs_identifier: Identifier,
-    pub assign: term!(=),
-    pub rhs_identifier: Identifier,
-    pub args: Braced<ArgumentList>,
-}
-
-impl Parse for ExtendedAttributeNamedArgList {
-    named!(parse -> Self, do_parse!(
-        lhs_identifier: weedle!(Identifier) >>
-        assign: weedle!(term!(=)) >>
-        rhs_identifier: weedle!(Identifier) >>
-        args: weedle!(Braced<ArgumentList>) >>
-        (ExtendedAttributeNamedArgList { lhs_identifier, assign, rhs_identifier, args })
-    ));
-}
-
-/// Parses an identifier list. Ex: `Exposed=((Window,Worker))`
-///
-/// (( )) means ( ) chars
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct ExtendedAttributeIdentList {
-    pub identifier: Identifier,
-    pub assign: term!(=),
-    pub list: Braced<IdentifierList>
-}
-
-impl Parse for ExtendedAttributeIdentList {
-    named!(parse -> Self, do_parse!(
-        identifier: weedle!(Identifier) >>
-        assign: weedle!(term!(=)) >>
-        list: weedle!(Braced<IdentifierList>) >>
-        (ExtendedAttributeIdentList { identifier, assign, list })
-    ));
-}
-
 /// Matches comma separated identifier list
 pub type IdentifierList = Punctuated<Identifier, term!(,)>;
 
-/// Parses an attribute with an identifier. Ex: `PutForwards=name`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct ExtendedAttributeIdent {
-    pub lhs_identifier: Identifier,
-    pub assign: term!(=),
-    pub rhs_identifier: Identifier
-}
+ast_types! {
+    /// Parses on of the forms of attribute
+    enum ExtendedAttribute {
+        /// Parses an argument list. Ex: `Constructor((double x, double y))`
+        ///
+        /// (( )) means ( ) chars
+        ArgList(struct ExtendedAttributeArgList {
+            identifier: Identifier,
+            args: Braced<ArgumentList>,
+        }),
+        /// Parses a named argument list. Ex: `NamedConstructor=Image((DOMString src))`
+        ///
+        /// (( )) means ( ) chars
+        NamedArgList(struct ExtendedAttributeNamedArgList {
+            lhs_identifier: Identifier,
+            assign: term!(=),
+            rhs_identifier: Identifier,
+            args: Braced<ArgumentList>,
 
-impl Parse for ExtendedAttributeIdent {
-    named!(parse -> Self, do_parse!(
-        lhs_identifier: weedle!(Identifier) >>
-        assign: weedle!(term!(=)) >>
-        rhs_identifier: weedle!(Identifier) >>
-        (ExtendedAttributeIdent { lhs_identifier, assign, rhs_identifier })
-    ));
-}
-
-/// Parses an argument list. Ex: `Constructor((double x, double y))`
-///
-/// (( )) means ( ) chars
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct ExtendedAttributeArgList {
-    pub identifier: Identifier,
-    pub args: Braced<ArgumentList>
-}
-
-impl Parse for ExtendedAttributeArgList {
-    named!(parse -> Self, do_parse!(
-        identifier: weedle!(Identifier) >>
-        args: weedle!(Braced<ArgumentList>) >>
-        (ExtendedAttributeArgList { identifier, args })
-    ));
-}
-
-/// Parses a plain attribute. Ex: `Replaceable`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct ExtendedAttributeNoArgs {
-    pub identifier: Identifier
-}
-
-impl Parse for ExtendedAttributeNoArgs {
-    named!(parse -> Self, do_parse!(
-        identifier: weedle!(Identifier) >>
-        (ExtendedAttributeNoArgs { identifier })
-    ));
+        }),
+        /// Parses an identifier list. Ex: `Exposed=((Window,Worker))`
+        ///
+        /// (( )) means ( ) chars
+        IdentList(struct ExtendedAttributeIdentList {
+            identifier: Identifier,
+            assign: term!(=),
+            list: Braced<IdentifierList>,
+        }),
+        /// Parses an attribute with an identifier. Ex: `PutForwards=name`
+        Ident(struct ExtendedAttributeIdent {
+            lhs_identifier: Identifier,
+            assign: term!(=),
+            rhs_identifier: Identifier,
+        }),
+        /// Parses a plain attribute. Ex: `Replaceable`
+        NoArgs(struct ExtendedAttributeNoArgs(
+            Identifier,
+        )),
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use Parse;
 
     test!(should_parse_attribute_no_args { "Replaceable" =>
         "";
-        ExtendedAttributeNoArgs;
-        identifier.name == "Replaceable";
+        ExtendedAttributeNoArgs => ExtendedAttributeNoArgs(Identifier("Replaceable".to_string()))
     });
 
     test!(should_parse_attribute_arg_list { "Constructor(double x, double y)" =>
         "";
         ExtendedAttributeArgList;
-        identifier.name == "Constructor";
+        identifier.0 == "Constructor";
         args.body.list.len() == 2;
     });
 
     test!(should_parse_attribute_ident { "PutForwards=name" =>
         "";
         ExtendedAttributeIdent;
-        lhs_identifier.name == "PutForwards";
-        rhs_identifier.name == "name";
+        lhs_identifier.0 == "PutForwards";
+        rhs_identifier.0 == "name";
     });
 
     test!(should_parse_ident_list { "Exposed=(Window,Worker)" =>
         "";
         ExtendedAttributeIdentList;
-        identifier.name == "Exposed";
+        identifier.0 == "Exposed";
         list.body.list.len() == 2;
     });
 
     test!(should_parse_named_arg_list { "NamedConstructor=Image(DOMString src)" =>
         "";
         ExtendedAttributeNamedArgList;
-        lhs_identifier.name == "NamedConstructor";
-        rhs_identifier.name == "Image";
+        lhs_identifier.0 == "NamedConstructor";
+        rhs_identifier.0 == "Image";
         args.body.list.len() == 1;
     });
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,6 @@
-use Parse;
+use literal::DefaultValue;
 use term;
-use literal::*;
+use Parse;
 
 impl<T: Parse> Parse for Option<T> {
     named!(parse -> Self, opt!(weedle!(T)));
@@ -35,130 +35,62 @@ impl<T: Parse, U: Parse, V: Parse> Parse for (T, U, V) {
     ));
 }
 
-/// Parses `{ body }`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct Parenthesized<T> {
-    pub open_paren: term::OpenParen,
-    pub body: T,
-    pub close_paren: term::CloseParen,
-}
+ast_types! {
+    /// Parses `{ body }`
+    struct Parenthesized(T) where [T: Parse] {
+        open_paren: term::OpenParen,
+        body: T,
+        close_paren: term::CloseParen,
+    }
 
-impl<T: Parse> Parse for Parenthesized<T> {
-    named!(parse -> Self, do_parse!(
-        open_paren: weedle!(term::OpenParen) >>
-        body: weedle!(T) >>
-        close_paren: weedle!(term::CloseParen) >>
-        (Parenthesized {  open_paren, body, close_paren })
-    ));
-}
+    /// Parses `[ body ]`
+    struct Bracketed(T) where [T: Parse] {
+        open_bracket: term::OpenBracket,
+        body: T,
+        close_bracket: term::CloseBracket,
+    }
 
-/// Parses `[ body ]`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct Bracketed<T> {
-    pub open_bracket: term::OpenBracket,
-    pub body: T,
-    pub close_bracket: term::CloseBracket,
-}
+    /// Parses `( body )`
+    struct Braced(T) where [T: Parse] {
+        open_brace: term::OpenBrace,
+        body: T,
+        close_brace: term::CloseBrace,
+    }
 
-impl<T: Parse> Parse for Bracketed<T> {
-    named!(parse -> Self, do_parse!(
-        open_bracket: weedle!(term::OpenBracket) >>
-        body: weedle!(T) >>
-        close_bracket: weedle!(term::CloseBracket) >>
-        (Bracketed { open_bracket, body, close_bracket })
-    ));
-}
+    /// Parses `< body >`
+    struct Generics(T) where [T: Parse] {
+        open_angle: term::LessThan,
+        body: T,
+        close_angle: term::GreaterThan,
+    }
 
-/// Parses `( body )`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct Braced<T> {
-    pub open_brace: term::OpenBrace,
-    pub body: T,
-    pub close_brace: term::CloseBrace,
-}
+    /// Parses `(item1, item2, item3,...)?`
+    struct Punctuated(T, S) where [T: Parse, S: Parse + ::std::default::Default] {
+        list: Vec<T> = separated_list!(weedle!(S), weedle!(T)),
+        separator: S = marker,
+    }
 
-impl<T: Parse> Parse for Braced<T> {
-    named!(parse -> Self, do_parse!(
-        open_brace: weedle!(term::OpenBrace) >>
-        body: weedle!(T) >>
-        close_brace: weedle!(term::CloseBrace) >>
-        (Braced { open_brace, body, close_brace })
-    ));
-}
+    /// Parses `item1, item2, item3, ...`
+    struct PunctuatedNonEmpty(T, S) where [T: Parse, S: Parse + ::std::default::Default] {
+        list: Vec<T> = separated_nonempty_list!(weedle!(S), weedle!(T)),
+        separator: S = marker,
+    }
 
-/// Parses `< body >`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct Generics<T> {
-    pub open_angle: term::LessThan,
-    pub body: T,
-    pub close_angle: term::GreaterThan
-}
+    /// Represents an identifier
+    ///
+    /// Follows `/_?[A-Za-z][0-9A-Z_a-z-]*/`
+    struct Identifier(
+        String = map!(
+            ws!(re_find_static!(r"^_?[A-Za-z][0-9A-Z_a-z-]*")),
+            |inner| inner.to_string()
+        ),
+    )
 
-impl<T: Parse> Parse for Generics<T> {
-    named!(parse -> Self, do_parse!(
-        open_angle: weedle!(term::LessThan) >>
-        body: weedle!(T) >>
-        close_angle: weedle!(term::GreaterThan) >>
-        (Generics { open_angle, body, close_angle })
-    ));
-}
-
-/// Parses `(item1, item2, item3,...)?`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct Punctuated<T, S> {
-    pub list: Vec<T>,
-    pub separator: S,
-}
-
-impl<T: Parse, S: Parse + ::std::default::Default> Parse for Punctuated<T, S> {
-    named!(parse -> Self, do_parse!(
-        list: separated_list!(weedle!(S), weedle!(T)) >>
-        (Punctuated { list, separator: S::default() })
-    ));
-}
-
-/// Parses `item1, item2, item3, ...`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct PunctuatedNonEmpty<T, S> {
-    pub list: Vec<T>,
-    pub separator: S
-}
-
-impl<T: Parse, S: Parse + ::std::default::Default> Parse for PunctuatedNonEmpty<T, S> {
-    named!(parse -> Self, do_parse!(
-        list: separated_nonempty_list!(weedle!(S), weedle!(T)) >>
-        (PunctuatedNonEmpty { list, separator: S::default() })
-    ));
-}
-
-/// Represents an identifier
-///
-/// Follows `/_?[A-Za-z][0-9A-Z_a-z-]*/`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct Identifier {
-    pub name: String
-}
-
-impl Parse for Identifier {
-    named!(parse -> Self, do_parse!(
-        name: ws!(re_capture_static!(r"^(_?[A-Za-z][0-9A-Z_a-z-]*)")) >>
-        (Identifier { name: name[0].to_string() })
-    ));
-}
-
-/// Parses rhs of an assignment expression. Ex: `= 45`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct Default {
-    pub assign: term!(=),
-    pub value: DefaultValue,
-}
-
-impl Parse for Default {
-    named!(parse -> Self, do_parse!(
-        assign: weedle!(term!(=)) >>
-        value: weedle!(DefaultValue) >>
-        (Default { assign, value })
-    ));
+    /// Parses rhs of an assignment expression. Ex: `= 45`
+    struct Default {
+        assign: term!(=),
+        value: DefaultValue,
+    }
 }
 
 #[cfg(test)]
@@ -191,32 +123,35 @@ mod test {
     test!(should_parse_parenthesized { "{ one }" =>
         "";
         Parenthesized<Identifier>;
-        body.name == "one";
+        body.0 == "one";
     });
 
     test!(should_parse_bracketed { "[ one ]" =>
         "";
         Bracketed<Identifier>;
-        body.name == "one";
+        body.0 == "one";
     });
 
     test!(should_parse_braced { "( one )" =>
         "";
         Braced<Identifier>;
-        body.name == "one";
+        body.0 == "one";
     });
 
     test!(should_parse_generics { "<one>" =>
         "";
         Generics<Identifier>;
-        body.name == "one";
+        body.0 == "one";
     });
 
     test!(should_parse_generics_two { "<one, two>" =>
         "";
-        Generics<(Identifier, term!(,), Identifier)>;
-        body.0.name == "one";
-        body.2.name == "two";
+        Generics<(Identifier, term!(,), Identifier)> =>
+            Generics {
+                open_angle: term!(<),
+                body: (Identifier("one".to_string()), term!(,), Identifier("two".to_string())),
+                close_angle: term!(>),
+            }
     });
 
     test!(should_parse_comma_separated_values { "one, two, three" =>
@@ -232,36 +167,36 @@ mod test {
     test!(should_parse_identifier { "hello" =>
         "";
         Identifier;
-        name == "hello";
+        0 == "hello";
     });
 
     test!(should_parse_numbered_identifier { "hello5" =>
         "";
         Identifier;
-        name == "hello5";
+        0 == "hello5";
     });
 
     test!(should_parse_underscored_identifier { "_hello_" =>
         "";
         Identifier;
-        name == "_hello_";
+        0 == "_hello_";
     });
 
     test!(should_parse_identifier_surrounding_with_spaces { "  hello  " =>
         "";
         Identifier;
-        name == "hello";
+        0 == "hello";
     });
 
     test!(should_parse_identifier_preceeding_others { "hello  note" =>
         "note";
         Identifier;
-        name == "hello";
+        0 == "hello";
     });
 
     test!(should_parse_identifier_attached_to_symbol { "hello=" =>
         "=";
         Identifier;
-        name == "hello";
+        0 == "hello";
     });
 }

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -3,16 +3,16 @@ use common::{Default, Identifier};
 use types::Type;
 
 /// Parses dictionary members
-pub type DictionaryMembers = Vec<DictionaryMember>;
+pub type DictionaryMembers<'a> = Vec<DictionaryMember<'a>>;
 
 ast_types! {
     /// Parses dictionary member `[attributes]? required? type identifier ( = default )?;`
-    struct DictionaryMember {
-        attributes: Option<ExtendedAttributeList>,
+    struct DictionaryMember<'a> {
+        attributes: Option<ExtendedAttributeList<'a>>,
         required: Option<term!(required)>,
-        type_: Type,
-        identifier: Identifier,
-        default: Option<Default>,
+        type_: Type<'a>,
+        identifier: Identifier<'a>,
+        default: Option<Default<'a>>,
         semi_colon: term!(;),
     }
 }

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -1,44 +1,33 @@
-use attribute::*;
-use types::*;
-use Parse;
-use common::*;
+use attribute::ExtendedAttributeList;
+use common::{Default, Identifier};
+use types::Type;
 
 /// Parses dictionary members
 pub type DictionaryMembers = Vec<DictionaryMember>;
 
-/// Parses dictionary member `[attributes]? required? type identifier ( = default )?;`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct DictionaryMember {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub required: Option<term!(required)>,
-    pub type_: Type,
-    pub identifier: Identifier,
-    pub default: Option<Default>,
-    pub semi_colon: term!(;)
-}
-
-impl Parse for DictionaryMember {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        required: weedle!(Option<term!(required)>) >>
-        type_: weedle!(Type) >>
-        identifier: weedle!(Identifier) >>
-        default: weedle!(Option<Default>) >>
-        semi_colon: weedle!(term!(;)) >>
-        (DictionaryMember { attributes, required, type_, identifier, default, semi_colon })
-    ));
+ast_types! {
+    /// Parses dictionary member `[attributes]? required? type identifier ( = default )?;`
+    struct DictionaryMember {
+        attributes: Option<ExtendedAttributeList>,
+        required: Option<term!(required)>,
+        type_: Type,
+        identifier: Identifier,
+        default: Option<Default>,
+        semi_colon: term!(;),
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use Parse;
 
     test!(should_parse_dictionary_member { "required long num = 5;" =>
         "";
         DictionaryMember;
         attributes.is_none();
         required.is_some();
-        identifier.name == "num";
+        identifier.0 == "num";
         default.is_some();
     });
 }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -5,82 +5,84 @@ use literal::ConstValue;
 use types::{AttributedType, ConstType, ReturnType};
 
 /// Parses interface members
-pub type InterfaceMembers = Vec<InterfaceMember>;
+pub type InterfaceMembers<'a> = Vec<InterfaceMember<'a>>;
 
 ast_types! {
     /// Parses inheritance clause `: identifier`
-    struct Inheritance {
+    #[derive(Copy)]
+    struct Inheritance<'a> {
         colon: term!(:),
-        identifier: Identifier,
+        identifier: Identifier<'a>,
     }
 
     /// Parses one of the interface member variants
-    enum InterfaceMember {
+    enum InterfaceMember<'a> {
         /// Parses a const interface member `[attributes]? const type identifier = value;`
-        Const(struct ConstMember {
-            attributes: Option<ExtendedAttributeList>,
+        Const(struct ConstMember<'a> {
+            attributes: Option<ExtendedAttributeList<'a>>,
             const_: term!(const),
-            const_type: ConstType,
-            identifier: Identifier,
+            const_type: ConstType<'a>,
+            identifier: Identifier<'a>,
             assign: term!(=),
-            const_value: ConstValue,
+            const_value: ConstValue<'a>,
             semi_colon: term!(;),
         }),
         /// Parses `[attributes]? (stringifier|inherit|static)? readonly? attribute attributedtype identifier;`
-        Attribute(struct AttributeInterfaceMember {
-            attributes: Option<ExtendedAttributeList>,
+        Attribute(struct AttributeInterfaceMember<'a> {
+            attributes: Option<ExtendedAttributeList<'a>>,
             modifier: Option<StringifierOrInheritOrStatic>,
             readonly: Option<term!(readonly)>,
             attribute: term!(attribute),
-            type_: AttributedType,
-            identifier: Identifier,
+            type_: AttributedType<'a>,
+            identifier: Identifier<'a>,
             semi_colon: term!(;),
         }),
         /// Parses `[attributes]? (stringifier|static)? specials? returntype identifier? (( args ));`
         ///
         /// (( )) means ( ) chars
-        Operation(struct OperationInterfaceMember {
-            attributes: Option<ExtendedAttributeList>,
+        Operation(struct OperationInterfaceMember<'a> {
+            attributes: Option<ExtendedAttributeList<'a>>,
             modifier: Option<StringifierOrStatic>,
             specials: Vec<Special>,
-            return_type: ReturnType,
-            identifier: Option<Identifier>,
-            args: Braced<ArgumentList>,
+            return_type: ReturnType<'a>,
+            identifier: Option<Identifier<'a>>,
+            args: Braced<ArgumentList<'a>>,
             semi_colon: term!(;),
         }),
         /// Parses an iterable declaration `[attributes]? (iterable<attributedtype> | iterable<attributedtype, attributedtype>) ;`
-        Iterable(enum IterableInterfaceMember {
+        Iterable(enum IterableInterfaceMember<'a> {
             /// Parses an iterable declaration `[attributes]? iterable<attributedtype>;`
-            Single(struct SingleTypedIterable {
-                attributes: Option<ExtendedAttributeList>,
+            Single(struct SingleTypedIterable<'a> {
+                attributes: Option<ExtendedAttributeList<'a>>,
                 iterable: term!(iterable),
-                generics: Generics<AttributedType>,
+                generics: Generics<AttributedType<'a>>,
                 semi_colon: term!(;),
             }),
             /// Parses an iterable declaration `[attributes]? iterable<attributedtype, attributedtype>;`
-            Double(struct DoubleTypedIterable {
-                attributes: Option<ExtendedAttributeList>,
+            Double(struct DoubleTypedIterable<'a> {
+                attributes: Option<ExtendedAttributeList<'a>>,
                 iterable: term!(iterable),
-                generics: Generics<(AttributedType, term!(,), AttributedType)>,
+                generics: Generics<(AttributedType<'a>, term!(,), AttributedType<'a>)>,
                 semi_colon: term!(;),
             }),
         }),
         /// Parses an maplike declaration `[attributes]? readonly? maplike<attributedtype, attributedtype>;`
-        Maplike(struct MaplikeInterfaceMember {
-            attributes: Option<ExtendedAttributeList>,
+        Maplike(struct MaplikeInterfaceMember<'a> {
+            attributes: Option<ExtendedAttributeList<'a>>,
             readonly: Option<term!(readonly)>,
             maplike: term!(maplike),
-            generics: Generics<(AttributedType, term!(,), AttributedType)>,
+            generics: Generics<(AttributedType<'a>, term!(,), AttributedType<'a>)>,
             semi_colon: term!(;),
         }),
-        Setlike(struct SetlikeInterfaceMember {
-            attributes: Option<ExtendedAttributeList>,
+        Setlike(struct SetlikeInterfaceMember<'a> {
+            attributes: Option<ExtendedAttributeList<'a>>,
             readonly: Option<term!(readonly)>,
             setlike: term!(setlike),
-            generics: Generics<AttributedType>,
+            generics: Generics<AttributedType<'a>>,
             semi_colon: term!(;),
         }),
         /// Parses `stringifier;`
+        #[derive(Copy, Default)]
         Stringifier(struct StringifierMember {
             stringifier: term!(stringifier),
             semi_colon: term!(;),
@@ -88,6 +90,7 @@ ast_types! {
     }
 
     /// Parses one of the special keyword `getter|setter|deleter`
+    #[derive(Copy)]
     enum Special {
         Getter(term!(getter)),
         Setter(term!(setter)),
@@ -95,6 +98,7 @@ ast_types! {
     }
 
     /// Parses `stringifier|inherit|static`
+    #[derive(Copy)]
     enum StringifierOrInheritOrStatic {
         Stringifier(term!(stringifier)),
         Inherit(term!(inherit)),
@@ -102,6 +106,7 @@ ast_types! {
     }
 
     /// Parses `stringifier|static`
+    #[derive(Copy)]
     enum StringifierOrStatic {
         Stringifier(term!(stringifier)),
         Static(term!(static)),

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,287 +1,117 @@
-use literal::*;
-use argument::*;
-use common::*;
-use Parse;
-use types::*;
-use attribute::*;
-
-/// Parses inheritance clause `: identifier`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct Inheritance {
-    pub colon: term!(:),
-    pub identifier: Identifier,
-}
-
-impl Parse for Inheritance {
-    named!(parse -> Self, do_parse!(
-        colon: weedle!(term!(:)) >>
-        identifier: weedle!(Identifier) >>
-        (Inheritance { colon, identifier })
-    ));
-}
+use argument::ArgumentList;
+use attribute::ExtendedAttributeList;
+use common::{Braced, Generics, Identifier};
+use literal::ConstValue;
+use types::{AttributedType, ConstType, ReturnType};
 
 /// Parses interface members
 pub type InterfaceMembers = Vec<InterfaceMember>;
 
-/// Parses one of the interface member variants
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub enum InterfaceMember {
-    Const(ConstMember),
-    Attribute(AttributeInterfaceMember),
-    Operation(OperationInterfaceMember),
-    Iterable(IterableInterfaceMember),
-    Maplike(MaplikeInterfaceMember),
-    Setlike(SetlikeInterfaceMember),
-    Stringifier(StringifierMember),
-}
+ast_types! {
+    /// Parses inheritance clause `: identifier`
+    struct Inheritance {
+        colon: term!(:),
+        identifier: Identifier,
+    }
 
-impl Parse for InterfaceMember {
-    named!(parse -> Self, alt!(
-        weedle!(ConstMember) => {|inner| InterfaceMember::Const(inner)} |
-        weedle!(AttributeInterfaceMember) => {|inner| InterfaceMember::Attribute(inner)} |
-        weedle!(OperationInterfaceMember) => {|inner| InterfaceMember::Operation(inner)} |
-        weedle!(IterableInterfaceMember) => {|inner| InterfaceMember::Iterable(inner)} |
-        weedle!(MaplikeInterfaceMember) => {|inner| InterfaceMember::Maplike(inner)} |
-        weedle!(SetlikeInterfaceMember) => {|inner| InterfaceMember::Setlike(inner)} |
-        weedle!(StringifierMember) => {|inner| InterfaceMember::Stringifier(inner)}
-    ));
-}
+    /// Parses one of the interface member variants
+    enum InterfaceMember {
+        /// Parses a const interface member `[attributes]? const type identifier = value;`
+        Const(struct ConstMember {
+            attributes: Option<ExtendedAttributeList>,
+            const_: term!(const),
+            const_type: ConstType,
+            identifier: Identifier,
+            assign: term!(=),
+            const_value: ConstValue,
+            semi_colon: term!(;),
+        }),
+        /// Parses `[attributes]? (stringifier|inherit|static)? readonly? attribute attributedtype identifier;`
+        Attribute(struct AttributeInterfaceMember {
+            attributes: Option<ExtendedAttributeList>,
+            modifier: Option<StringifierOrInheritOrStatic>,
+            readonly: Option<term!(readonly)>,
+            attribute: term!(attribute),
+            type_: AttributedType,
+            identifier: Identifier,
+            semi_colon: term!(;),
+        }),
+        /// Parses `[attributes]? (stringifier|static)? specials? returntype identifier? (( args ));`
+        ///
+        /// (( )) means ( ) chars
+        Operation(struct OperationInterfaceMember {
+            attributes: Option<ExtendedAttributeList>,
+            modifier: Option<StringifierOrStatic>,
+            specials: Vec<Special>,
+            return_type: ReturnType,
+            identifier: Option<Identifier>,
+            args: Braced<ArgumentList>,
+            semi_colon: term!(;),
+        }),
+        /// Parses an iterable declaration `[attributes]? (iterable<attributedtype> | iterable<attributedtype, attributedtype>) ;`
+        Iterable(enum IterableInterfaceMember {
+            /// Parses an iterable declaration `[attributes]? iterable<attributedtype>;`
+            Single(struct SingleTypedIterable {
+                attributes: Option<ExtendedAttributeList>,
+                iterable: term!(iterable),
+                generics: Generics<AttributedType>,
+                semi_colon: term!(;),
+            }),
+            /// Parses an iterable declaration `[attributes]? iterable<attributedtype, attributedtype>;`
+            Double(struct DoubleTypedIterable {
+                attributes: Option<ExtendedAttributeList>,
+                iterable: term!(iterable),
+                generics: Generics<(AttributedType, term!(,), AttributedType)>,
+                semi_colon: term!(;),
+            }),
+        }),
+        /// Parses an maplike declaration `[attributes]? readonly? maplike<attributedtype, attributedtype>;`
+        Maplike(struct MaplikeInterfaceMember {
+            attributes: Option<ExtendedAttributeList>,
+            readonly: Option<term!(readonly)>,
+            maplike: term!(maplike),
+            generics: Generics<(AttributedType, term!(,), AttributedType)>,
+            semi_colon: term!(;),
+        }),
+        Setlike(struct SetlikeInterfaceMember {
+            attributes: Option<ExtendedAttributeList>,
+            readonly: Option<term!(readonly)>,
+            setlike: term!(setlike),
+            generics: Generics<AttributedType>,
+            semi_colon: term!(;),
+        }),
+        /// Parses `stringifier;`
+        Stringifier(struct StringifierMember {
+            stringifier: term!(stringifier),
+            semi_colon: term!(;),
+        }),
+    }
 
-/// Parses a const interface member `[attributes]? const type identifier = value;`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct ConstMember {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub const_: term!(const),
-    pub const_type: ConstType,
-    pub identifier: Identifier,
-    pub assign: term!(=),
-    pub const_value: ConstValue,
-    pub semi_colon: term!(;)
-}
+    /// Parses one of the special keyword `getter|setter|deleter`
+    enum Special {
+        Getter(term!(getter)),
+        Setter(term!(setter)),
+        Deleter(term!(deleter)),
+    }
 
-impl Parse for ConstMember {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        const_: weedle!(term!(const)) >>
-        const_type: weedle!(ConstType) >>
-        identifier: weedle!(Identifier) >>
-        assign: weedle!(term!(=)) >>
-        const_value: weedle!(ConstValue) >>
-        semi_colon: weedle!(term!(;)) >>
-        (ConstMember { attributes, const_, const_type, identifier, assign, const_value, semi_colon })
-    ));
-}
+    /// Parses `stringifier|inherit|static`
+    enum StringifierOrInheritOrStatic {
+        Stringifier(term!(stringifier)),
+        Inherit(term!(inherit)),
+        Static(term!(static)),
+    }
 
-/// Parses `[attributes]? (stringifier|inherit|static)? readonly? attribute attributedtype identifier;`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct AttributeInterfaceMember {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub modifier: Option<StringifierOrInheritOrStatic>,
-    pub readonly: Option<term!(readonly)>,
-    pub attribute: term!(attribute),
-    pub type_: AttributedType,
-    pub identifier: Identifier,
-    pub semi_colon: term!(;)
-}
-
-impl Parse for AttributeInterfaceMember {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        modifier: weedle!(Option<StringifierOrInheritOrStatic>) >>
-        readonly: weedle!(Option<term!(readonly)>) >>
-        attribute: weedle!(term!(attribute)) >>
-        type_: weedle!(AttributedType) >>
-        identifier: weedle!(Identifier) >>
-        semi_colon: weedle!(term!(;)) >>
-        (AttributeInterfaceMember { attributes, modifier, readonly, attribute, type_, identifier, semi_colon })
-    ));
-}
-
-/// Parses `[attributes]? (stringifier|static)? specials? returntype identifier? (( args ));`
-///
-/// (( )) means ( ) chars
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct OperationInterfaceMember {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub modifier: Option<StringifierOrStatic>,
-    pub specials: Vec<Special>,
-    pub return_type: ReturnType,
-    pub identifier: Option<Identifier>,
-    pub args: Braced<ArgumentList>,
-    pub semi_colon: term!(;)
-}
-
-impl Parse for OperationInterfaceMember {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        modifier: weedle!(Option<StringifierOrStatic>) >>
-        specials: weedle!(Vec<Special>) >>
-        return_type: weedle!(ReturnType) >>
-        identifier: weedle!(Option<Identifier>) >>
-        args: weedle!(Braced<ArgumentList>) >>
-        semi_colon: weedle!(term!(;)) >>
-        (OperationInterfaceMember { attributes, modifier, specials, return_type, identifier, args, semi_colon })
-    ));
-}
-
-/// Parses one of the special keyword `getter|setter|deleter`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub enum Special {
-    Getter(term!(getter)),
-    Setter(term!(setter)),
-    Deleter(term!(deleter))
-}
-
-impl Parse for Special {
-    named!(parse -> Self, alt!(
-        weedle!(term!(getter)) => {|inner| Special::Getter(inner)} |
-        weedle!(term!(setter)) => {|inner| Special::Setter(inner)} |
-        weedle!(term!(deleter)) => {|inner| Special::Deleter(inner)}
-    ));
-}
-
-/// Parses an iterable declaration `[attributes]? (iterable<attributedtype> | iterable<attributedtype, attributedtype>) ;`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub enum IterableInterfaceMember {
-    Single(SingleTypedIterable),
-    Double(DoubleTypedIterable)
-}
-
-impl Parse for IterableInterfaceMember {
-    named!(parse -> Self, alt!(
-        weedle!(SingleTypedIterable) => {|inner| IterableInterfaceMember::Single(inner)} |
-        weedle!(DoubleTypedIterable) => {|inner| IterableInterfaceMember::Double(inner)}
-    ));
-}
-
-/// Parses an iterable declaration `[attributes]? iterable<attributedtype>;`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct SingleTypedIterable {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub iterable: term!(iterable),
-    pub generics: Generics<AttributedType>,
-    pub semi_colon: term!(;)
-}
-
-impl Parse for SingleTypedIterable {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        iterable: weedle!(term!(iterable)) >>
-        generics: weedle!(Generics<AttributedType>) >>
-        semi_colon: weedle!(term!(;)) >>
-        (SingleTypedIterable { attributes, iterable, generics, semi_colon })
-    ));
-}
-
-/// Parses an iterable declaration `[attributes]? iterable<attributedtype, attributedtype>;`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct DoubleTypedIterable {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub iterable: term!(iterable),
-    pub generics: Generics<(AttributedType, term!(,), AttributedType)>,
-    pub semi_colon: term!(;)
-}
-
-impl Parse for DoubleTypedIterable {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        iterable: weedle!(term!(iterable)) >>
-        generics: weedle!(Generics<(AttributedType, term!(,), AttributedType)>) >>
-        semi_colon: weedle!(term!(;)) >>
-        (DoubleTypedIterable { attributes, iterable, generics, semi_colon })
-    ));
-}
-
-/// Parses an maplike declaration `[attributes]? readonly? maplike<attributedtype, attributedtype>;`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct MaplikeInterfaceMember {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub readonly: Option<term!(readonly)>,
-    pub maplike: term!(maplike),
-    pub generics: Generics<(AttributedType, term!(,), AttributedType)>,
-    pub semi_colon: term!(;)
-}
-
-impl Parse for MaplikeInterfaceMember {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        readonly: weedle!(Option<term!(readonly)>) >>
-        maplike: weedle!(term!(maplike)) >>
-        generics: weedle!(Generics<(AttributedType, term!(,), AttributedType)>) >>
-        semi_colon: weedle!(term!(;)) >>
-        (MaplikeInterfaceMember { attributes, readonly, maplike, generics, semi_colon })
-    ));
-}
-
-/// Parses an setlike declaration `[attributes]? readonly? setlike<attributedtype>;`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct SetlikeInterfaceMember {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub readonly: Option<term!(readonly)>,
-    pub setlike: term!(setlike),
-    pub generics: Generics<AttributedType>,
-    pub semi_colon: term!(;)
-}
-
-impl Parse for SetlikeInterfaceMember {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        readonly: weedle!(Option<term!(readonly)>) >>
-        setlike: weedle!(term!(setlike)) >>
-        generics: weedle!(Generics<AttributedType>) >>
-        semi_colon: weedle!(term!(;)) >>
-        (SetlikeInterfaceMember { attributes, readonly, setlike, generics, semi_colon })
-    ));
-}
-
-/// Parses `stringifier|inherit|static`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub enum StringifierOrInheritOrStatic {
-    Stringifier(term!(stringifier)),
-    Inherit(term!(inherit)),
-    Static(term!(static))
-}
-
-impl Parse for StringifierOrInheritOrStatic {
-    named!(parse -> Self, alt!(
-        weedle!(term!(stringifier)) => {|inner| StringifierOrInheritOrStatic::Stringifier(inner)} |
-        weedle!(term!(inherit)) => {|inner| StringifierOrInheritOrStatic::Inherit(inner)} |
-        weedle!(term!(static)) => {|inner| StringifierOrInheritOrStatic::Static(inner)}
-    ));
-}
-
-/// Parses `stringifier|static`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub enum StringifierOrStatic {
-    Stringifier(term!(stringifier)),
-    Static(term!(static))
-}
-
-impl Parse for StringifierOrStatic {
-    named!(parse -> Self, alt!(
-        weedle!(term!(stringifier)) => {|inner| StringifierOrStatic::Stringifier(inner)} |
-        weedle!(term!(static)) => {|inner| StringifierOrStatic::Static(inner)}
-    ));
-}
-
-/// Parses `stringifier;`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct StringifierMember {
-    pub stringifier: term!(stringifier),
-    pub semi_colon: term!(;)
-}
-
-impl Parse for StringifierMember {
-    named!(parse -> Self, do_parse!(
-        stringifier: weedle!(term!(stringifier)) >>
-        semi_colon: weedle!(term!(;)) >>
-        (StringifierMember { stringifier, semi_colon })
-    ));
+    /// Parses `stringifier|static`
+    enum StringifierOrStatic {
+        Stringifier(term!(stringifier)),
+        Static(term!(static)),
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use Parse;
 
     test!(should_parse_stringifier_member { "stringifier;" =>
         "";
@@ -317,7 +147,7 @@ mod test {
         AttributeInterfaceMember;
         attributes.is_none();
         readonly == Some(term!(readonly));
-        identifier.name == "width";
+        identifier.0 == "width";
     });
 
     test!(should_parse_double_typed_iterable { "iterable<long, long>;" =>
@@ -345,6 +175,6 @@ mod test {
         "";
         ConstMember;
         attributes.is_none();
-        identifier.name == "name";
+        identifier.0 == "name";
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,13 +72,13 @@ pub mod types;
 ///
 /// println!("{:?}", parsed);
 /// ```
-pub fn parse(raw: &str) -> Result<Definitions, Err<CompleteStr, u32>> {
+pub fn parse<'a>(raw: &'a str) -> Result<Definitions<'a>, Err<CompleteStr<'a>, u32>> {
     let (_, parsed) = Definitions::parse(CompleteStr(raw))?;
     Ok(parsed)
 }
 
-pub trait Parse: Sized {
-    fn parse(input: CompleteStr) -> IResult<CompleteStr, Self>;
+pub trait Parse<'a>: Sized {
+    fn parse(input: CompleteStr<'a>) -> IResult<CompleteStr<'a>, Self>;
 }
 
 /// Parses WebIDL definitions. It is the root struct for a complete WebIDL definition.
@@ -97,132 +97,132 @@ pub trait Parse: Sized {
 /// ```
 ///
 /// It is recommended to use [`parse`](fn.parse.html) instead.
-pub type Definitions = Vec<Definition>;
+pub type Definitions<'a> = Vec<Definition<'a>>;
 
 ast_types! {
     /// Parses a definition
-    enum Definition {
+    enum Definition<'a> {
         /// Parses `[attributes]? callback identifier = type ( (arg1, arg2, ..., argN)? );`
-        Callback(struct CallbackDefinition {
-            attributes: Option<ExtendedAttributeList>,
+        Callback(struct CallbackDefinition<'a> {
+            attributes: Option<ExtendedAttributeList<'a>>,
             callback: term!(callback),
-            identifier: Identifier,
+            identifier: Identifier<'a>,
             assign: term!(=),
-            return_type: ReturnType,
-            arguments: Braced<ArgumentList>,
+            return_type: ReturnType<'a>,
+            arguments: Braced<ArgumentList<'a>>,
             semi_colon: term!(;),
         }),
         /// Parses `[attributes]? callback interface identifier ( : inheritance )? { members };`
-        CallbackInterface(struct CallbackInterfaceDefinition {
-            attributes: Option<ExtendedAttributeList>,
+        CallbackInterface(struct CallbackInterfaceDefinition<'a> {
+            attributes: Option<ExtendedAttributeList<'a>>,
             callback: term!(callback),
             interface: term!(interface),
-            identifier: Identifier,
-            inheritance: Option<Inheritance>,
-            members: Parenthesized<InterfaceMembers>,
+            identifier: Identifier<'a>,
+            inheritance: Option<Inheritance<'a>>,
+            members: Parenthesized<InterfaceMembers<'a>>,
             semi_colon: term!(;),
         }),
         /// Parses `[attributes]? interface identifier ( : inheritance )? { members };`
-        Interface(struct InterfaceDefinition {
-            attributes: Option<ExtendedAttributeList>,
+        Interface(struct InterfaceDefinition<'a> {
+            attributes: Option<ExtendedAttributeList<'a>>,
             interface: term!(interface),
-            identifier: Identifier,
-            inheritance: Option<Inheritance>,
-            members: Parenthesized<InterfaceMembers>,
+            identifier: Identifier<'a>,
+            inheritance: Option<Inheritance<'a>>,
+            members: Parenthesized<InterfaceMembers<'a>>,
             semi_colon: term!(;),
         }),
         /// Parses `[attributes]? interface mixin identifier { members };`
-        InterfaceMixin(struct InterfaceMixinDefinition {
-            attributes: Option<ExtendedAttributeList>,
+        InterfaceMixin(struct InterfaceMixinDefinition<'a> {
+            attributes: Option<ExtendedAttributeList<'a>>,
             interface: term!(interface),
             mixin: term!(mixin),
-            identifier: Identifier,
-            members: Parenthesized<MixinMembers>,
+            identifier: Identifier<'a>,
+            members: Parenthesized<MixinMembers<'a>>,
             semi_colon: term!(;),
         }),
         /// Parses `[attributes]? namespace identifier { members };`
-        Namespace(struct NamespaceDefinition {
-            attributes: Option<ExtendedAttributeList>,
+        Namespace(struct NamespaceDefinition<'a> {
+            attributes: Option<ExtendedAttributeList<'a>>,
             namespace: term!(namespace),
-            identifier: Identifier,
-            members: Parenthesized<NamespaceMembers>,
+            identifier: Identifier<'a>,
+            members: Parenthesized<NamespaceMembers<'a>>,
             semi_colon: term!(;),
         }),
         /// Parses `[attributes]? dictionary identifier ( : inheritance )? { members };`
-        Dictionary(struct DictionaryDefinition {
-            attributes: Option<ExtendedAttributeList>,
+        Dictionary(struct DictionaryDefinition<'a> {
+            attributes: Option<ExtendedAttributeList<'a>>,
             dictionary: term!(dictionary),
-            identifier: Identifier,
-            inheritance: Option<Inheritance>,
-            members: Parenthesized<DictionaryMembers>,
+            identifier: Identifier<'a>,
+            inheritance: Option<Inheritance<'a>>,
+            members: Parenthesized<DictionaryMembers<'a>>,
             semi_colon: term!(;),
         }),
         /// Parses `[attributes]? partial interface identifier { members };`
-        PartialInterface(struct PartialInterfaceDefinition {
-            attributes: Option<ExtendedAttributeList>,
+        PartialInterface(struct PartialInterfaceDefinition<'a> {
+            attributes: Option<ExtendedAttributeList<'a>>,
             partial: term!(partial),
             interface: term!(interface),
-            identifier: Identifier,
-            members: Parenthesized<InterfaceMembers>,
+            identifier: Identifier<'a>,
+            members: Parenthesized<InterfaceMembers<'a>>,
             semi_colon: term!(;),
         }),
         /// Parses `[attributes]? partial interface mixin identifier { members };`
-        PartialInterfaceMixin(struct PartialInterfaceMixinDefinition {
-            attributes: Option<ExtendedAttributeList>,
+        PartialInterfaceMixin(struct PartialInterfaceMixinDefinition<'a> {
+            attributes: Option<ExtendedAttributeList<'a>>,
             partial: term!(partial),
             interface: term!(interface),
             mixin: term!(mixin),
-            identifier: Identifier,
-            members: Parenthesized<MixinMembers>,
+            identifier: Identifier<'a>,
+            members: Parenthesized<MixinMembers<'a>>,
             semi_colon: term!(;),
         }),
         /// Parses `[attributes]? partial dictionary identifier { members };`
-        PartialDictionary(struct PartialDictionaryDefinition {
-            attributes: Option<ExtendedAttributeList>,
+        PartialDictionary(struct PartialDictionaryDefinition<'a> {
+            attributes: Option<ExtendedAttributeList<'a>>,
             partial: term!(partial),
             dictionary: term!(dictionary),
-            identifier: Identifier,
-            members: Parenthesized<DictionaryMembers>,
+            identifier: Identifier<'a>,
+            members: Parenthesized<DictionaryMembers<'a>>,
             semi_colon: term!(;),
         }),
         /// Parses `[attributes]? partial namespace identifier { members };`
-        PartialNamespace(struct PartialNamespaceDefinition {
-            attributes: Option<ExtendedAttributeList>,
+        PartialNamespace(struct PartialNamespaceDefinition<'a> {
+            attributes: Option<ExtendedAttributeList<'a>>,
             partial: term!(partial),
             namespace: term!(namespace),
-            identifier: Identifier,
-            members: Parenthesized<NamespaceMembers>,
+            identifier: Identifier<'a>,
+            members: Parenthesized<NamespaceMembers<'a>>,
             semi_colon: term!(;),
         }),
         /// Parses `[attributes]? enum identifier { values };`
-        Enum(struct EnumDefinition {
-            attributes: Option<ExtendedAttributeList>,
+        Enum(struct EnumDefinition<'a> {
+            attributes: Option<ExtendedAttributeList<'a>>,
             enum_: term!(enum),
-            identifier: Identifier,
-            values: Parenthesized<EnumValueList>,
+            identifier: Identifier<'a>,
+            values: Parenthesized<EnumValueList<'a>>,
             semi_colon: term!(;),
         }),
         /// Parses `[attributes]? typedef attributedtype identifier;`
-        Typedef(struct TypedefDefinition {
-            attributes: Option<ExtendedAttributeList>,
+        Typedef(struct TypedefDefinition<'a> {
+            attributes: Option<ExtendedAttributeList<'a>>,
             typedef: term!(typedef),
-            type_: AttributedType,
-            identifier: Identifier,
+            type_: AttributedType<'a>,
+            identifier: Identifier<'a>,
             semi_colon: term!(;),
         }),
         /// Parses `[attributes]? identifier includes identifier;`
-        IncludesStatement(struct IncludesStatementDefinition {
-            attributes: Option<ExtendedAttributeList>,
-            lhs_identifier: Identifier,
+        IncludesStatement(struct IncludesStatementDefinition<'a> {
+            attributes: Option<ExtendedAttributeList<'a>>,
+            lhs_identifier: Identifier<'a>,
             includes: term!(includes),
-            rhs_identifier: Identifier,
+            rhs_identifier: Identifier<'a>,
             semi_colon: term!(;),
         }),
     }
 }
 
 /// Parses a non-empty enum value list
-pub type EnumValueList = PunctuatedNonEmpty<StringLit, term!(,)>;
+pub type EnumValueList<'a> = PunctuatedNonEmpty<StringLit<'a>, term!(,)>;
 
 #[cfg(test)]
 mod test {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,22 +21,25 @@
 //!
 //! If any flaws found when parsing string with a valid grammar, create an issue.
 
+// need a higher recusion limit for macros
+#![recursion_limit = "128"]
+
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
 extern crate nom;
 extern crate regex;
 
-use argument::*;
-use attribute::*;
-use common::*;
-use dictionary::*;
-use interface::*;
-use namespace::*;
-use types::*;
-use mixin::*;
-use literal::*;
-pub use nom::{IResult, types::CompleteStr, Err};
+use argument::ArgumentList;
+use attribute::ExtendedAttributeList;
+use common::{Braced, Identifier, Parenthesized, PunctuatedNonEmpty};
+use dictionary::DictionaryMembers;
+use interface::{Inheritance, InterfaceMembers};
+use literal::StringLit;
+use mixin::MixinMembers;
+use namespace::NamespaceMembers;
+pub use nom::{types::CompleteStr, Err, IResult};
+use types::{AttributedType, ReturnType};
 
 #[macro_use]
 mod whitespace;
@@ -44,15 +47,15 @@ mod whitespace;
 mod macros;
 #[macro_use]
 pub mod term;
-pub mod literal;
-pub mod attribute;
 pub mod argument;
-pub mod types;
+pub mod attribute;
 pub mod common;
-pub mod interface;
-pub mod mixin;
 pub mod dictionary;
+pub mod interface;
+pub mod literal;
+pub mod mixin;
 pub mod namespace;
+pub mod types;
 
 /// A convenient parse function
 ///
@@ -94,349 +97,128 @@ pub trait Parse: Sized {
 /// ```
 ///
 /// It is recommended to use [`parse`](fn.parse.html) instead.
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct Definitions {
-    pub definitions: Vec<Definition>
-}
+pub type Definitions = Vec<Definition>;
 
-impl Parse for Definitions {
-    named!(parse -> Self, do_parse!(
-        definitions: many0!(weedle!(Definition)) >>
-        (Definitions { definitions })
-    ));
-}
-
-/// Parses a definition
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub enum Definition {
-    Callback(CallbackDefinition),
-    CallbackInterface(CallbackInterfaceDefinition),
-    Interface(InterfaceDefinition),
-    InterfaceMixin(InterfaceMixinDefinition),
-    Namespace(NamespaceDefinition),
-    Dictionary(DictionaryDefinition),
-    PartialInterface(PartialInterfaceDefinition),
-    PartialInterfaceMixin(PartialInterfaceMixinDefinition),
-    PartialDictionary(PartialDictionaryDefinition),
-    PartialNamespace(PartialNamespaceDefinition),
-    Enum(EnumDefinition),
-    Typedef(TypedefDefinition),
-    IncludesStatement(IncludesStatementDefinition),
-}
-
-impl Parse for Definition {
-    named!(parse -> Self, alt!(
-        weedle!(CallbackDefinition) => {|inner| Definition::Callback(inner)} |
-        weedle!(CallbackInterfaceDefinition) => {|inner| Definition::CallbackInterface(inner)} |
-        weedle!(InterfaceDefinition) => {|inner| Definition::Interface(inner)} |
-        weedle!(InterfaceMixinDefinition) => {|inner| Definition::InterfaceMixin(inner)} |
-        weedle!(NamespaceDefinition) => {|inner| Definition::Namespace(inner)} |
-        weedle!(DictionaryDefinition) => {|inner| Definition::Dictionary(inner)} |
-        weedle!(PartialInterfaceDefinition) => {|inner| Definition::PartialInterface(inner)} |
-        weedle!(PartialInterfaceMixinDefinition) => {|inner| Definition::PartialInterfaceMixin(inner)} |
-        weedle!(PartialDictionaryDefinition) => {|inner| Definition::PartialDictionary(inner)} |
-        weedle!(PartialNamespaceDefinition) => {|inner| Definition::PartialNamespace(inner)} |
-        weedle!(EnumDefinition) => {|inner| Definition::Enum(inner)} |
-        weedle!(TypedefDefinition) => {|inner| Definition::Typedef(inner)} |
-        weedle!(IncludesStatementDefinition) => {|inner| Definition::IncludesStatement(inner)}
-    ));
-}
-
-/// Parses `[attributes]? callback identifier = type ( (arg1, arg2, ..., argN)? );`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct CallbackDefinition {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub callback: term!(callback),
-    pub identifier: Identifier,
-    pub assign: term!(=),
-    pub return_type: ReturnType,
-    pub arguments: Braced<ArgumentList>,
-    pub semi_colon: term!(;),
-}
-
-impl Parse for CallbackDefinition {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        callback: weedle!(term!(callback)) >>
-        identifier: weedle!(Identifier) >>
-        assign: weedle!(term!(=)) >>
-        return_type: weedle!(ReturnType) >>
-        arguments: weedle!(Braced<ArgumentList>) >>
-        semi_colon: weedle!(term!(;)) >>
-        (CallbackDefinition { attributes, callback, identifier, assign, return_type, arguments, semi_colon })
-    ));
-}
-
-/// Parses `[attributes]? callback interface identifier ( : inheritance )? { members };`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct CallbackInterfaceDefinition {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub callback: term!(callback),
-    pub interface: term!(interface),
-    pub identifier: Identifier,
-    pub inheritance: Option<Inheritance>,
-    pub members: Parenthesized<InterfaceMembers>,
-    pub semi_colon: term!(;),
-}
-
-impl Parse for CallbackInterfaceDefinition {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        callback: weedle!(term!(callback)) >>
-        interface: weedle!(term!(interface)) >>
-        identifier: weedle!(Identifier) >>
-        inheritance: weedle!(Option<Inheritance>) >>
-        members: weedle!(Parenthesized<InterfaceMembers>) >>
-        semi_colon: weedle!(term!(;)) >>
-        (CallbackInterfaceDefinition { attributes, callback, interface, identifier, inheritance, members, semi_colon })
-    ));
-}
-
-/// Parses `[attributes]? interface identifier ( : inheritance )? { members };`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct InterfaceDefinition {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub interface: term!(interface),
-    pub identifier: Identifier,
-    pub inheritance: Option<Inheritance>,
-    pub members: Parenthesized<InterfaceMembers>,
-    pub semi_colon: term!(;)
-}
-
-impl Parse for InterfaceDefinition {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        interface: weedle!(term!(interface)) >>
-        identifier: weedle!(Identifier) >>
-        inheritance: weedle!(Option<Inheritance>) >>
-        members: weedle!(Parenthesized<InterfaceMembers>) >>
-        semi_colon: weedle!(term!(;)) >>
-        (InterfaceDefinition { attributes, interface, identifier, inheritance, members, semi_colon })
-    ));
-}
-
-/// Parses `[attributes]? interface mixin identifier { members };`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct InterfaceMixinDefinition {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub interface: term!(interface),
-    pub mixin: term!(mixin),
-    pub identifier: Identifier,
-    pub members: Parenthesized<MixinMembers>,
-    pub semi_colon: term!(;)
-}
-
-impl Parse for InterfaceMixinDefinition {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        interface: weedle!(term!(interface)) >>
-        mixin: weedle!(term!(mixin)) >>
-        identifier: weedle!(Identifier) >>
-        members: weedle!(Parenthesized<MixinMembers>) >>
-        semi_colon: weedle!(term!(;)) >>
-        (InterfaceMixinDefinition { attributes, interface, mixin, identifier, members, semi_colon })
-    ));
-}
-
-/// Parses `[attributes]? namespace identifier { members };`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct NamespaceDefinition {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub namespace: term!(namespace),
-    pub identifier: Identifier,
-    pub members: Parenthesized<NamespaceMembers>,
-    pub semi_colon: term!(;)
-}
-
-impl Parse for NamespaceDefinition {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        namespace: weedle!(term!(namespace)) >>
-        identifier: weedle!(Identifier) >>
-        members: weedle!(Parenthesized<NamespaceMembers>) >>
-        semi_colon: weedle!(term!(;)) >>
-        (NamespaceDefinition { attributes, namespace, identifier, members, semi_colon })
-    ));
-}
-
-/// Parses `[attributes]? partial interface identifier { members };`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct PartialInterfaceDefinition {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub partial: term!(partial),
-    pub interface: term!(interface),
-    pub identifier: Identifier,
-    pub members: Parenthesized<InterfaceMembers>,
-    pub semi_colon: term!(;)
-}
-
-impl Parse for PartialInterfaceDefinition {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        partial: weedle!(term!(partial)) >>
-        interface: weedle!(term!(interface)) >>
-        identifier: weedle!(Identifier) >>
-        members: weedle!(Parenthesized<InterfaceMembers>) >>
-        semi_colon: weedle!(term!(;)) >>
-        (PartialInterfaceDefinition { attributes, partial, interface, identifier, members, semi_colon })
-    ));
-}
-
-/// Parses `[attributes]? partial interface mixin identifier { members };`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct PartialInterfaceMixinDefinition {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub partial: term!(partial),
-    pub interface: term!(interface),
-    pub mixin: term!(mixin),
-    pub identifier: Identifier,
-    pub members: Parenthesized<MixinMembers>,
-    pub semi_colon: term!(;)
-}
-
-impl Parse for PartialInterfaceMixinDefinition {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        partial: weedle!(term!(partial)) >>
-        interface: weedle!(term!(interface)) >>
-        mixin: weedle!(term!(mixin)) >>
-        identifier: weedle!(Identifier) >>
-        members: weedle!(Parenthesized<MixinMembers>) >>
-        semi_colon: weedle!(term!(;)) >>
-        (PartialInterfaceMixinDefinition { attributes, partial, interface, mixin, identifier, members, semi_colon })
-    ));
-}
-
-/// Parses `[attributes]? partial dictionary identifier { members };`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct PartialDictionaryDefinition {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub partial: term!(partial),
-    pub dictionary: term!(dictionary),
-    pub identifier: Identifier,
-    pub members: Parenthesized<DictionaryMembers>,
-    pub semi_colon: term!(;)
-}
-
-impl Parse for PartialDictionaryDefinition {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        partial: weedle!(term!(partial)) >>
-        dictionary: weedle!(term!(dictionary)) >>
-        identifier: weedle!(Identifier) >>
-        members: weedle!(Parenthesized<DictionaryMembers>) >>
-        semi_colon: weedle!(term!(;)) >>
-        (PartialDictionaryDefinition { attributes, partial, dictionary, identifier, members, semi_colon })
-    ));
-}
-
-/// Parses `[attributes]? partial namespace identifier { members };`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct PartialNamespaceDefinition {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub partial: term!(partial),
-    pub namespace: term!(namespace),
-    pub identifier: Identifier,
-    pub members: Parenthesized<NamespaceMembers>,
-    pub semi_colon: term!(;)
-}
-
-impl Parse for PartialNamespaceDefinition {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        partial: weedle!(term!(partial)) >>
-        namespace: weedle!(term!(namespace)) >>
-        identifier: weedle!(Identifier) >>
-        members: weedle!(Parenthesized<NamespaceMembers>) >>
-        semi_colon: weedle!(term!(;)) >>
-        (PartialNamespaceDefinition { attributes, partial, namespace, identifier, members, semi_colon })
-    ));
-}
-
-/// Parses `[attributes]? dictionary identifier ( : inheritance )? { members };`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct DictionaryDefinition {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub dictionary: term!(dictionary),
-    pub identifier: Identifier,
-    pub inheritance: Option<Inheritance>,
-    pub members: Parenthesized<DictionaryMembers>,
-    pub semi_colon: term!(;)
-}
-
-impl Parse for DictionaryDefinition {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        dictionary: weedle!(term!(dictionary)) >>
-        identifier: weedle!(Identifier) >>
-        inheritance: weedle!(Option<Inheritance>) >>
-        members: weedle!(Parenthesized<DictionaryMembers>) >>
-        semi_colon: weedle!(term!(;)) >>
-        (DictionaryDefinition { attributes, dictionary, identifier, inheritance, members, semi_colon })
-    ));
-}
-
-/// Parses `[attributes]? enum identifier { values };`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct EnumDefinition {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub enum_: term!(enum),
-    pub identifier: Identifier,
-    pub values: Parenthesized<EnumValueList>,
-    pub semi_colon: term!(;)
-}
-
-impl Parse for EnumDefinition {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        enum_: weedle!(term!(enum)) >>
-        identifier: weedle!(Identifier) >>
-        values: weedle!(Parenthesized<EnumValueList>) >>
-        semi_colon: weedle!(term!(;)) >>
-        (EnumDefinition { attributes, enum_, identifier, values, semi_colon })
-    ));
-}
-
-/// Parses `[attributes]? typedef attributedtype identifier;`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct TypedefDefinition {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub typedef: term!(typedef),
-    pub type_: AttributedType,
-    pub identifier: Identifier,
-    pub semi_colon: term!(;)
-}
-
-impl Parse for TypedefDefinition {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        typedef: weedle!(term!(typedef)) >>
-        type_: weedle!(AttributedType) >>
-        identifier: weedle!(Identifier) >>
-        semi_colon: weedle!(term!(;)) >>
-        (TypedefDefinition { attributes, typedef, type_, identifier, semi_colon })
-    ));
-}
-
-/// Parses `[attributes]? identifier includes identifier;`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct IncludesStatementDefinition {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub lhs_identifier: Identifier,
-    pub includes: term!(includes),
-    pub rhs_identifier: Identifier,
-    pub semi_colon: term!(;)
-}
-
-impl Parse for IncludesStatementDefinition {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        lhs_identifier: weedle!(Identifier) >>
-        includes: weedle!(term!(includes)) >>
-        rhs_identifier: weedle!(Identifier) >>
-        semi_colon: weedle!(term!(;)) >>
-        (IncludesStatementDefinition { attributes, lhs_identifier, includes, rhs_identifier, semi_colon })
-    ));
+ast_types! {
+    /// Parses a definition
+    enum Definition {
+        /// Parses `[attributes]? callback identifier = type ( (arg1, arg2, ..., argN)? );`
+        Callback(struct CallbackDefinition {
+            attributes: Option<ExtendedAttributeList>,
+            callback: term!(callback),
+            identifier: Identifier,
+            assign: term!(=),
+            return_type: ReturnType,
+            arguments: Braced<ArgumentList>,
+            semi_colon: term!(;),
+        }),
+        /// Parses `[attributes]? callback interface identifier ( : inheritance )? { members };`
+        CallbackInterface(struct CallbackInterfaceDefinition {
+            attributes: Option<ExtendedAttributeList>,
+            callback: term!(callback),
+            interface: term!(interface),
+            identifier: Identifier,
+            inheritance: Option<Inheritance>,
+            members: Parenthesized<InterfaceMembers>,
+            semi_colon: term!(;),
+        }),
+        /// Parses `[attributes]? interface identifier ( : inheritance )? { members };`
+        Interface(struct InterfaceDefinition {
+            attributes: Option<ExtendedAttributeList>,
+            interface: term!(interface),
+            identifier: Identifier,
+            inheritance: Option<Inheritance>,
+            members: Parenthesized<InterfaceMembers>,
+            semi_colon: term!(;),
+        }),
+        /// Parses `[attributes]? interface mixin identifier { members };`
+        InterfaceMixin(struct InterfaceMixinDefinition {
+            attributes: Option<ExtendedAttributeList>,
+            interface: term!(interface),
+            mixin: term!(mixin),
+            identifier: Identifier,
+            members: Parenthesized<MixinMembers>,
+            semi_colon: term!(;),
+        }),
+        /// Parses `[attributes]? namespace identifier { members };`
+        Namespace(struct NamespaceDefinition {
+            attributes: Option<ExtendedAttributeList>,
+            namespace: term!(namespace),
+            identifier: Identifier,
+            members: Parenthesized<NamespaceMembers>,
+            semi_colon: term!(;),
+        }),
+        /// Parses `[attributes]? dictionary identifier ( : inheritance )? { members };`
+        Dictionary(struct DictionaryDefinition {
+            attributes: Option<ExtendedAttributeList>,
+            dictionary: term!(dictionary),
+            identifier: Identifier,
+            inheritance: Option<Inheritance>,
+            members: Parenthesized<DictionaryMembers>,
+            semi_colon: term!(;),
+        }),
+        /// Parses `[attributes]? partial interface identifier { members };`
+        PartialInterface(struct PartialInterfaceDefinition {
+            attributes: Option<ExtendedAttributeList>,
+            partial: term!(partial),
+            interface: term!(interface),
+            identifier: Identifier,
+            members: Parenthesized<InterfaceMembers>,
+            semi_colon: term!(;),
+        }),
+        /// Parses `[attributes]? partial interface mixin identifier { members };`
+        PartialInterfaceMixin(struct PartialInterfaceMixinDefinition {
+            attributes: Option<ExtendedAttributeList>,
+            partial: term!(partial),
+            interface: term!(interface),
+            mixin: term!(mixin),
+            identifier: Identifier,
+            members: Parenthesized<MixinMembers>,
+            semi_colon: term!(;),
+        }),
+        /// Parses `[attributes]? partial dictionary identifier { members };`
+        PartialDictionary(struct PartialDictionaryDefinition {
+            attributes: Option<ExtendedAttributeList>,
+            partial: term!(partial),
+            dictionary: term!(dictionary),
+            identifier: Identifier,
+            members: Parenthesized<DictionaryMembers>,
+            semi_colon: term!(;),
+        }),
+        /// Parses `[attributes]? partial namespace identifier { members };`
+        PartialNamespace(struct PartialNamespaceDefinition {
+            attributes: Option<ExtendedAttributeList>,
+            partial: term!(partial),
+            namespace: term!(namespace),
+            identifier: Identifier,
+            members: Parenthesized<NamespaceMembers>,
+            semi_colon: term!(;),
+        }),
+        /// Parses `[attributes]? enum identifier { values };`
+        Enum(struct EnumDefinition {
+            attributes: Option<ExtendedAttributeList>,
+            enum_: term!(enum),
+            identifier: Identifier,
+            values: Parenthesized<EnumValueList>,
+            semi_colon: term!(;),
+        }),
+        /// Parses `[attributes]? typedef attributedtype identifier;`
+        Typedef(struct TypedefDefinition {
+            attributes: Option<ExtendedAttributeList>,
+            typedef: term!(typedef),
+            type_: AttributedType,
+            identifier: Identifier,
+            semi_colon: term!(;),
+        }),
+        /// Parses `[attributes]? identifier includes identifier;`
+        IncludesStatement(struct IncludesStatementDefinition {
+            attributes: Option<ExtendedAttributeList>,
+            lhs_identifier: Identifier,
+            includes: term!(includes),
+            rhs_identifier: Identifier,
+            semi_colon: term!(;),
+        }),
+    }
 }
 
 /// Parses a non-empty enum value list
@@ -450,22 +232,22 @@ mod test {
         "";
         IncludesStatementDefinition;
         attributes.is_none();
-        lhs_identifier.name == "first";
-        rhs_identifier.name == "second";
+        lhs_identifier.0 == "first";
+        rhs_identifier.0 == "second";
     });
 
     test!(should_parse_typedef { "typedef short Short;" =>
         "";
         TypedefDefinition;
         attributes.is_none();
-        identifier.name == "Short";
+        identifier.0 == "Short";
     });
 
     test!(should_parse_enum { r#"enum name { "first", "second" }; "# =>
         "";
         EnumDefinition;
         attributes.is_none();
-        identifier.name == "name";
+        identifier.0 == "name";
         values.body.list.len() == 2;
     });
 
@@ -473,7 +255,7 @@ mod test {
         "";
         DictionaryDefinition;
         attributes.is_none();
-        identifier.name == "A";
+        identifier.0 == "A";
         inheritance.is_none();
         members.body.len() == 2;
     });
@@ -482,7 +264,7 @@ mod test {
         "";
         DictionaryDefinition;
         attributes.is_none();
-        identifier.name == "C";
+        identifier.0 == "C";
         inheritance.is_some();
         members.body.len() == 2;
     });
@@ -497,7 +279,7 @@ mod test {
         "";
         PartialNamespaceDefinition;
         attributes.is_none();
-        identifier.name == "VectorUtils";
+        identifier.0 == "VectorUtils";
         members.body.len() == 3;
     });
 
@@ -505,7 +287,7 @@ mod test {
         "";
         PartialDictionaryDefinition;
         attributes.is_none();
-        identifier.name == "C";
+        identifier.0 == "C";
         members.body.len() == 2;
     });
 
@@ -517,7 +299,7 @@ mod test {
         "";
         PartialInterfaceMixinDefinition;
         attributes.is_none();
-        identifier.name == "WindowSessionStorage";
+        identifier.0 == "WindowSessionStorage";
         members.body.len() == 1;
     });
 
@@ -529,7 +311,7 @@ mod test {
         "";
         PartialInterfaceDefinition;
         attributes.is_none();
-        identifier.name == "Window";
+        identifier.0 == "Window";
         members.body.len() == 1;
     });
 
@@ -543,7 +325,7 @@ mod test {
         "";
         NamespaceDefinition;
         attributes.is_none();
-        identifier.name == "VectorUtils";
+        identifier.0 == "VectorUtils";
         members.body.len() == 3;
     });
 
@@ -555,7 +337,7 @@ mod test {
         "";
         InterfaceMixinDefinition;
         attributes.is_none();
-        identifier.name == "WindowSessionStorage";
+        identifier.0 == "WindowSessionStorage";
         members.body.len() == 1;
     });
 
@@ -567,7 +349,7 @@ mod test {
         "";
         InterfaceDefinition;
         attributes.is_none();
-        identifier.name == "Window";
+        identifier.0 == "Window";
         members.body.len() == 1;
     });
 
@@ -581,7 +363,7 @@ mod test {
         "";
         CallbackInterfaceDefinition;
         attributes.is_none();
-        identifier.name == "Options";
+        identifier.0 == "Options";
         members.body.len() == 3;
     });
 
@@ -589,7 +371,7 @@ mod test {
         "";
         CallbackDefinition;
         attributes.is_none();
-        identifier.name == "AsyncOperationCallback";
+        identifier.0 == "AsyncOperationCallback";
         arguments.body.list.len() == 1;
     });
 

--- a/src/literal.rs
+++ b/src/literal.rs
@@ -1,299 +1,160 @@
-use Parse;
-use nom::types::CompleteStr;
-use std::str::FromStr;
-
-/// Represents other literal symbols
-///
-/// Follows `/[^\t\n\r 0-9A-Za-z]/`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct OtherLit(pub String);
-
-impl Parse for OtherLit {
-    named!(parse -> Self, do_parse!(
-        value: ws!(re_capture_static!(r"^([^\t\n\r 0-9A-Za-z])")) >>
-        (OtherLit(value[0].to_string()))
-    ));
-}
-
-impl OtherLit {
-    pub fn value(&self) -> &str {
-        &self.0
+ast_types! {
+    /// Represents an integer value
+    enum IntegerLit {
+        /// Parses `-?[1-9][0-9]*`
+        Dec(struct DecLit(
+            String = map!(
+                ws!(re_find_static!(r"^-?[1-9][0-9]*")),
+                |inner| inner.to_string()
+            ),
+        )),
+        /// Parses `-?0[Xx][0-9A-Fa-f]+)`
+        Hex(struct HexLit(
+            String = map!(
+                ws!(re_find_static!(r"^-?0[Xx][0-9A-Fa-f]+")),
+                |inner| inner.to_string()
+            ),
+        )),
+        /// Parses `-?0[0-7]*`
+        Oct(struct OctLit(
+            String = map!(
+                ws!(re_find_static!(r"^-?0[0-7]*")),
+                |inner| inner.to_string()
+            ),
+        )),
     }
-}
 
-/// Parses `-?[1-9][0-9]*`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct DecI64(pub String);
+    /// Represents a string value
+    ///
+    /// Follow `/"[^"]*"/`
+    struct StringLit(
+        String = map!(
+            ws!(re_find_static!(r#"^"[^"]*""#)),
+            |quoted| quoted[1..quoted.len()-1].to_string()
+        ),
+    )
 
-impl Parse for DecI64 {
-    named!(parse -> Self, do_parse!(
-        num: ws!(re_capture_static!(r"^(-?[1-9][0-9]*)")) >>
-        (DecI64(num[0].to_string()))
-    ));
-}
-
-impl DecI64 {
-    pub fn value(&self) -> i64 {
-        i64::from_str_radix(&self.0, 10).unwrap()
+    /// Represents a default literal value. Ex: `34|34.23|"value"|[ ]|true|false|null`
+    enum DefaultValue {
+        Boolean(BooleanLit),
+        /// Represents `[ ]`
+        #[derive(Copy, Default)]
+        EmptyArray(struct EmptyArrayLit {
+            open_bracket: term!(OpenBracket),
+            close_bracket: term!(CloseBracket),
+        }),
+        Float(FloatLit),
+        Integer(IntegerLit),
+        Null(term!(null)),
+        String(StringLit),
     }
-}
 
-/// Parses `-?0[Xx][0-9A-Fa-f]+)`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct HexI64(pub String);
-
-impl Parse for HexI64 {
-    named!(parse -> Self, do_parse!(
-        num: ws!(re_capture_static!(r"^(-?0[Xx][0-9A-Fa-f]+)")) >>
-        (HexI64(num[0].to_string()))
-    ));
-}
-
-impl HexI64 {
-    pub fn value(&self) -> i64 {
-        i64::from_str_radix(&self.0[2..], 16).unwrap()
+    /// Represents `true`, `false`, `34.23`, `null`, `56`, ...
+    enum ConstValue {
+        Boolean(BooleanLit),
+        Float(FloatLit),
+        Integer(IntegerLit),
+        Null(term!(null)),
     }
-}
 
-/// Parses `-?0[0-7]*`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct OctI64(pub String);
+    /// Represents either `true` or `false`
+    #[derive(Copy)]
+    struct BooleanLit(
+        bool = alt!(
+            weedle!(term!(true)) => {|_| true} |
+            weedle!(term!(false)) => {|_| false}
+        ),
+    )
 
-impl Parse for OctI64 {
-    named!(parse -> Self, do_parse!(
-        num: ws!(re_capture_static!(r"^(-?0[0-7]*)")) >>
-        (OctI64(num[0].to_string()))
-    ));
-}
-
-impl OctI64 {
-    pub fn value(&self) -> i64 {
-        i64::from_str_radix(&self.0, 8).unwrap()
-    }
-}
-
-/// Represents an integer value
-///
-/// Follows `/-?([1-9][0-9]*|0[Xx][0-9A-Fa-f]+|0[0-7]*)/`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub enum IntegerLit {
-    Dec(DecI64),
-    Hex(HexI64),
-    Oct(OctI64)
-}
-
-impl Parse for IntegerLit {
-    named!(parse -> Self, alt!(
-        weedle!(DecI64) => {|num| IntegerLit::Dec(num)} |
-        weedle!(HexI64) => {|num| IntegerLit::Hex(num)} |
-        weedle!(OctI64) => {|num| IntegerLit::Oct(num)}
-    ));
-}
-
-impl IntegerLit {
-    pub fn value(&self) -> i64 {
-        match *self {
-            IntegerLit::Dec(ref dec) => dec.value(),
-            IntegerLit::Hex(ref hex) => hex.value(),
-            IntegerLit::Oct(ref oct) => oct.value()
-        }
-    }
-}
-
-/// Represents a string value
-///
-/// Follow `/"[^"]*"/`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct StringLit(pub String);
-
-impl Parse for StringLit {
-    named!(parse -> Self, do_parse!(
-        value: ws!(re_capture_static!(r#"^("[^"]*")"#)) >>
-        ({
-            let quoted = value[0];
-            let unquoted = &quoted[1..quoted.len() - 1];
-            StringLit(unquoted.to_string())
-        })
-    ));
-}
-
-impl StringLit {
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-/// Represents a default literal value. Ex: `34|34.23|"value"|[ ]|true|false|null`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub enum DefaultValue {
-    Null(term!(null)),
-    EmptyArray(EmptyArrayLit),
-    String(StringLit),
-    Boolean(BooleanLit),
-    Float(FloatLit),
-    Integer(IntegerLit),
-}
-
-impl Parse for DefaultValue {
-    named!(parse -> Self, alt!(
-        weedle!(term!(null)) => {|inner| DefaultValue::Null(inner)} |
-        weedle!(EmptyArrayLit) => {|inner| DefaultValue::EmptyArray(inner)} |
-        weedle!(StringLit) => {|inner| DefaultValue::String(inner)} |
-        weedle!(BooleanLit) => {|inner| DefaultValue::Boolean(inner)} |
-        weedle!(FloatLit) => {|inner| DefaultValue::Float(inner)} |
-        weedle!(IntegerLit) => {|inner| DefaultValue::Integer(inner)}
-    ));
-}
-
-/// Represents `[ ]`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct EmptyArrayLit(pub [(); 0]);
-
-impl Parse for EmptyArrayLit {
-    named!(parse -> Self, do_parse!(
-        weedle!(term!(OpenBracket)) >>
-        weedle!(term!(CloseBracket)) >>
-        (EmptyArrayLit([]))
-    ));
-}
-
-/// Represents `true`, `false`, `34.23`, `null`, `56`, ...
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub enum ConstValue {
-    Boolean(BooleanLit),
-    Float(FloatLit),
-    Integer(IntegerLit),
-    Null(term!(null)),
-}
-
-impl Parse for ConstValue {
-    named!(parse -> Self, alt!(
-        weedle!(BooleanLit) => {|inner| ConstValue::Boolean(inner)} |
-        weedle!(FloatLit) => {|inner| ConstValue::Float(inner)} |
-        weedle!(IntegerLit) => {|inner| ConstValue::Integer(inner)} |
-        weedle!(term!(null)) => {|inner| ConstValue::Null(inner)}
-    ));
-}
-
-/// Represents either `true` or `false`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct BooleanLit(pub bool);
-
-impl Parse for BooleanLit {
-    named!(parse -> Self, alt!(
-        weedle!(term!(true)) => {|_| BooleanLit(true)} |
-        weedle!(term!(false)) => {|_| BooleanLit(false)}
-    ));
-}
-
-impl BooleanLit {
-    pub fn value(&self) -> bool {
-        self.0
-    }
-}
-
-/// Represents a floating point value, `NaN`, `Infinity`, '+Infinity`
-///
-/// Follows `/-?(([0-9]+\.[0-9]*|[0-9]*\.[0-9]+)([Ee][+-]?[0-9]+)?|[0-9]+[Ee][+-]?[0-9]+)/`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub enum FloatLit {
-    Value(String),
-    NegInfinity(term!(-Infinity)),
-    Infinity(term!(Infinity)),
-    NaN(term!(NaN))
-}
-
-impl Parse for FloatLit {
-    named!(parse -> Self, alt!(
-        ws!(re_capture_static!(r"^(-?(([0-9]+\.[0-9]*|[0-9]*\.[0-9]+)([Ee][+-]?[0-9]+)?|[0-9]+[Ee][+-]?[0-9]+))"))
-            => {|inner: Vec<CompleteStr>| FloatLit::Value(inner[0].to_string())} |
-        weedle!(term!(-Infinity)) => {|inner| FloatLit::NegInfinity(inner)} |
-        weedle!(term!(Infinity)) => {|inner| FloatLit::Infinity(inner)} |
-        weedle!(term!(NaN)) => {|inner| FloatLit::NaN(inner)}
-    ));
-}
-
-impl FloatLit {
-    pub fn value(&self) -> f64 {
-        match *self {
-            FloatLit::Value(ref value) => f64::from_str(&value).unwrap(),
-            FloatLit::NegInfinity(_) => ::std::f64::NEG_INFINITY,
-            FloatLit::Infinity(_) => ::std::f64::INFINITY,
-            FloatLit::NaN(_) => ::std::f64::NAN
-        }
+    /// Represents a floating point value, `NaN`, `Infinity`, '+Infinity`
+    enum FloatLit {
+        /// Parses `/-?(([0-9]+\.[0-9]*|[0-9]*\.[0-9]+)([Ee][+-]?[0-9]+)?|[0-9]+[Ee][+-]?[0-9]+)/`
+        Value(struct FloatValueLit(
+            String = map!(
+                ws!(re_find_static!(r"^-?(?:(?:[0-9]+\.[0-9]*|[0-9]*\.[0-9]+)(?:[Ee][+-]?[0-9]+)?|[0-9]+[Ee][+-]?[0-9]+)")),
+                |inner| inner.to_string()
+            ),
+        )),
+        NegInfinity(term!(-Infinity)),
+        Infinity(term!(Infinity)),
+        NaN(term!(NaN)),
     }
 }
 
 #[cfg(test)]
 mod test {
-    use Parse;
     use super::*;
     use term::*;
-
-    test!(should_parse_other_lit { "&" =>
-        "";
-        OtherLit;
-        0 == "&";
-    });
+    use Parse;
 
     test!(should_parse_integer { "45" =>
         "";
-        IntegerLit => IntegerLit::Dec(DecI64("45".to_string()))
+        IntegerLit => IntegerLit::Dec(DecLit("45".to_string()))
     });
 
     test!(should_parse_integer_surrounding_with_spaces { "  123123  " =>
         "";
-        IntegerLit => IntegerLit::Dec(DecI64("123123".to_string()))
+        IntegerLit => IntegerLit::Dec(DecLit("123123".to_string()))
     });
 
     test!(should_parse_integer_preceeding_others { "3453 string" =>
         "string";
-        IntegerLit => IntegerLit::Dec(DecI64("3453".to_string()))
+        IntegerLit => IntegerLit::Dec(DecLit("3453".to_string()))
     });
 
     test!(should_parse_neg_integer { "-435" =>
         "";
-        IntegerLit => IntegerLit::Dec(DecI64("-435".to_string()))
+        IntegerLit => IntegerLit::Dec(DecLit("-435".to_string()))
     });
 
     test!(should_parse_hex_number { "0X08" =>
         "";
-        IntegerLit => IntegerLit::Hex(HexI64("0X08".to_string()))
+        IntegerLit => IntegerLit::Hex(HexLit("0X08".to_string()))
     });
 
     test!(should_parse_hex_large_number { "0xA" =>
         "";
-        IntegerLit => IntegerLit::Hex(HexI64("0xA".to_string()))
+        IntegerLit => IntegerLit::Hex(HexLit("0xA".to_string()))
+    });
+
+    test!(should_parse_zero { "0" =>
+        "";
+        IntegerLit => IntegerLit::Oct(OctLit("0".to_string()))
+    });
+
+    test!(should_parse_oct_number { "-07561" =>
+        "";
+        IntegerLit => IntegerLit::Oct(OctLit("-07561".to_string()))
     });
 
     test!(should_parse_float { "45.434" =>
         "";
-        FloatLit => FloatLit::Value("45.434".to_string())
+        FloatLit => FloatLit::Value(FloatValueLit("45.434".to_string()))
     });
 
     test!(should_parse_float_surrounding_with_spaces { "  2345.2345  " =>
         "";
-        FloatLit => FloatLit::Value("2345.2345".to_string())
+        FloatLit => FloatLit::Value(FloatValueLit("2345.2345".to_string()))
     });
 
     test!(should_parse_float_preceeding_others { "3453.32334 string" =>
         "string";
-        FloatLit => FloatLit::Value("3453.32334".to_string())
+        FloatLit => FloatLit::Value(FloatValueLit("3453.32334".to_string()))
     });
 
     test!(should_parse_neg_float { "-435.3435" =>
         "";
-        FloatLit => FloatLit::Value("-435.3435".to_string())
+        FloatLit => FloatLit::Value(FloatValueLit("-435.3435".to_string()))
     });
 
     test!(should_parse_float_exp { "5.3434e23" =>
         "";
-        FloatLit => FloatLit::Value("5.3434e23".to_string())
+        FloatLit => FloatLit::Value(FloatValueLit("5.3434e23".to_string()))
     });
 
     test!(should_parse_float_exp_with_decimal { "3e23" =>
         "";
-        FloatLit => FloatLit::Value("3e23".to_string())
+        FloatLit => FloatLit::Value(FloatValueLit("3e23".to_string()))
     });
 
     test!(should_parse_neg_infinity { "-Infinity" =>
@@ -328,11 +189,16 @@ mod test {
 
     test!(should_parse_empty_array { "[]" =>
         "";
-        EmptyArrayLit => EmptyArrayLit([])
+        EmptyArrayLit => Default::default()
     });
 
-    test!(should_parse_bool { "true" =>
+    test!(should_parse_bool_true { "true" =>
         "";
         BooleanLit => BooleanLit(true)
+    });
+
+    test!(should_parse_bool_false { "false" =>
+        "";
+        BooleanLit => BooleanLit(false)
     });
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -30,22 +30,6 @@ macro_rules! opt_flat(
   );
 );
 
-// Pass if condition is true else error out
-#[macro_export]
-macro_rules! err_if_not(
-    ($i:expr, $cond:expr) => (
-        {
-            use $crate::nom::{Convert,Err,ErrorKind};
-            let default_err = Err(Err::convert(Err::Error(error_position!($i, ErrorKind::CondReduce::<u32>))));
-
-            if $cond {
-                Ok(($i, ""))
-            } else {
-                default_err
-            }
-        }
-    );
-);
 
 #[cfg(test)]
 macro_rules! test {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -13,29 +13,6 @@ macro_rules! weedle {
     };
 }
 
-// Workaround to use `CompleteStr`
-macro_rules! re_capture_static (
-  ($i:expr, $re:expr) => (
-    {
-      use $crate::nom::{Err,ErrorKind,IResult};
-      use $crate::nom::Slice;
-
-      regex!(RE, $re);
-      if let Some(c) = RE.captures(&$i) {
-        let v:Vec<_> = c.iter().filter(|el| el.is_some()).map(|el| el.unwrap()).map(|m| $i.slice(m.start()..m.end())).collect();
-        let offset = {
-          let end = v.last().unwrap();
-          end.as_ptr() as usize + end.len() - $i.as_ptr() as usize
-        };
-        Ok(($i.slice(offset..), v))
-      } else {
-        let res: IResult<_,_> = Err(Err::Error(error_position!($i, ErrorKind::RegexpCapture::<u32>)));
-        res
-      }
-    }
-  )
-);
-
 // Return valid option as it is & convert `Error` to `None`
 #[macro_export]
 macro_rules! opt_flat(

--- a/src/mixin.rs
+++ b/src/mixin.rs
@@ -1,84 +1,45 @@
-use Parse;
-use common::*;
-use argument::*;
-use interface::*;
-use types::*;
-use attribute::*;
+use argument::ArgumentList;
+use attribute::ExtendedAttributeList;
+use common::{Braced, Identifier};
+use interface::{ConstMember, StringifierMember};
+use types::{AttributedType, ReturnType};
 
 /// Parses the members declarations of a mixin
 pub type MixinMembers = Vec<MixinMember>;
 
-/// Parses one of the variants of a mixin member
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub enum MixinMember {
-    Const(ConstMember),
-    Operation(OperationMixinMember),
-    Attribute(AttributeMixinMember),
-    Stringifier(StringifierMember)
-}
-
-impl Parse for MixinMember {
-    named!(parse -> Self, alt!(
-        weedle!(ConstMember) => {|inner| MixinMember::Const(inner)} |
-        weedle!(OperationMixinMember) => {|inner| MixinMember::Operation(inner)} |
-        weedle!(AttributeMixinMember) => {|inner| MixinMember::Attribute(inner)} |
-        weedle!(StringifierMember) => {|inner| MixinMember::Stringifier(inner)}
-    ));
-}
-
-/// Parses `[attributes]? stringifier? returntype identifier? (( args ));`
-///
-/// (( )) means ( ) chars
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct OperationMixinMember {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub stringifier: Option<term!(stringifier)>,
-    pub return_type: ReturnType,
-    pub identifier: Option<Identifier>,
-    pub args: Braced<ArgumentList>,
-    pub semi_colon: term!(;)
-}
-
-impl Parse for OperationMixinMember {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        stringifier: weedle!(Option<term!(stringifier)>) >>
-        return_type: weedle!(ReturnType) >>
-        identifier: weedle!(Option<Identifier>) >>
-        args: weedle!(Braced<ArgumentList>) >>
-        semi_colon: weedle!(term!(;)) >>
-        (OperationMixinMember { attributes, stringifier, return_type, identifier, args, semi_colon })
-    ));
-}
-
-/// Parses `[attributes]? stringifier? readonly? attribute attributedtype identifier;`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct AttributeMixinMember {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub stringifier: Option<term!(stringifier)>,
-    pub readonly: Option<term!(readonly)>,
-    pub attribute: term!(attribute),
-    pub type_: AttributedType,
-    pub identifier: Identifier,
-    pub semi_colon: term!(;)
-}
-
-impl Parse for AttributeMixinMember {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        stringifier: weedle!(Option<term!(stringifier)>) >>
-        readonly: weedle!(Option<term!(readonly)>) >>
-        attribute: weedle!(term!(attribute)) >>
-        type_: weedle!(AttributedType) >>
-        identifier: weedle!(Identifier) >>
-        semi_colon: weedle!(term!(;)) >>
-        (AttributeMixinMember { attributes, stringifier, readonly, attribute, type_, identifier, semi_colon })
-    ));
+ast_types! {
+    /// Parses one of the variants of a mixin member
+    enum MixinMember {
+        Const(ConstMember),
+        /// Parses `[attributes]? stringifier? returntype identifier? (( args ));`
+        ///
+        /// (( )) means ( ) chars
+        Operation(struct OperationMixinMember {
+            attributes: Option<ExtendedAttributeList>,
+            stringifier: Option<term!(stringifier)>,
+            return_type: ReturnType,
+            identifier: Option<Identifier>,
+            args: Braced<ArgumentList>,
+            semi_colon: term!(;),
+        }),
+        /// Parses `[attributes]? stringifier? readonly? attribute attributedtype identifier;`
+        Attribute(struct AttributeMixinMember {
+            attributes: Option<ExtendedAttributeList>,
+            stringifier: Option<term!(stringifier)>,
+            readonly: Option<term!(readonly)>,
+            attribute: term!(attribute),
+            type_: AttributedType,
+            identifier: Identifier,
+            semi_colon: term!(;),
+        }),
+        Stringifier(StringifierMember),
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use Parse;
 
     test!(should_parse_attribute_mixin_member { "stringifier readonly attribute short name;" =>
         "";
@@ -86,7 +47,7 @@ mod test {
         attributes.is_none();
         stringifier.is_some();
         readonly.is_some();
-        identifier.name == "name";
+        identifier.0 == "name";
     });
 
     test!(should_parse_operation_mixin_member { "short fnName(long a);" =>

--- a/src/mixin.rs
+++ b/src/mixin.rs
@@ -5,31 +5,31 @@ use interface::{ConstMember, StringifierMember};
 use types::{AttributedType, ReturnType};
 
 /// Parses the members declarations of a mixin
-pub type MixinMembers = Vec<MixinMember>;
+pub type MixinMembers<'a> = Vec<MixinMember<'a>>;
 
 ast_types! {
     /// Parses one of the variants of a mixin member
-    enum MixinMember {
-        Const(ConstMember),
+    enum MixinMember<'a> {
+        Const(ConstMember<'a>),
         /// Parses `[attributes]? stringifier? returntype identifier? (( args ));`
         ///
         /// (( )) means ( ) chars
-        Operation(struct OperationMixinMember {
-            attributes: Option<ExtendedAttributeList>,
+        Operation(struct OperationMixinMember<'a> {
+            attributes: Option<ExtendedAttributeList<'a>>,
             stringifier: Option<term!(stringifier)>,
-            return_type: ReturnType,
-            identifier: Option<Identifier>,
-            args: Braced<ArgumentList>,
+            return_type: ReturnType<'a>,
+            identifier: Option<Identifier<'a>>,
+            args: Braced<ArgumentList<'a>>,
             semi_colon: term!(;),
         }),
         /// Parses `[attributes]? stringifier? readonly? attribute attributedtype identifier;`
-        Attribute(struct AttributeMixinMember {
-            attributes: Option<ExtendedAttributeList>,
+        Attribute(struct AttributeMixinMember<'a> {
+            attributes: Option<ExtendedAttributeList<'a>>,
             stringifier: Option<term!(stringifier)>,
             readonly: Option<term!(readonly)>,
             attribute: term!(attribute),
-            type_: AttributedType,
-            identifier: Identifier,
+            type_: AttributedType<'a>,
+            identifier: Identifier<'a>,
             semi_colon: term!(;),
         }),
         Stringifier(StringifierMember),

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -4,28 +4,28 @@ use common::{Braced, Identifier};
 use types::{AttributedType, ReturnType};
 
 /// Parses namespace members declaration
-pub type NamespaceMembers = Vec<NamespaceMember>;
+pub type NamespaceMembers<'a> = Vec<NamespaceMember<'a>>;
 
 ast_types! {
     /// Parses namespace member declaration
-    enum NamespaceMember {
+    enum NamespaceMember<'a> {
         /// Parses `[attributes]? returntype identifier? (( args ));`
         ///
         /// (( )) means ( ) chars
-        Operation(struct OperationNamespaceMember {
-            attributes: Option<ExtendedAttributeList>,
-            return_type: ReturnType,
-            identifier: Option<Identifier>,
-            args: Braced<ArgumentList>,
+        Operation(struct OperationNamespaceMember<'a> {
+            attributes: Option<ExtendedAttributeList<'a>>,
+            return_type: ReturnType<'a>,
+            identifier: Option<Identifier<'a>>,
+            args: Braced<ArgumentList<'a>>,
             semi_colon: term!(;),
         }),
         /// Parses `[attribute]? readonly attributetype type identifier;`
-        Attribute(struct AttributeNamespaceMember {
-            attributes: Option<ExtendedAttributeList>,
+        Attribute(struct AttributeNamespaceMember<'a> {
+            attributes: Option<ExtendedAttributeList<'a>>,
             readonly: term!(readonly),
             attribute: term!(attribute),
-            type_: AttributedType,
-            identifier: Identifier,
+            type_: AttributedType<'a>,
+            identifier: Identifier<'a>,
             semi_colon: term!(;),
         }),
     }

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -1,81 +1,46 @@
-use common::*;
-use argument::*;
-use types::*;
-use Parse;
-use attribute::*;
+use argument::ArgumentList;
+use attribute::ExtendedAttributeList;
+use common::{Braced, Identifier};
+use types::{AttributedType, ReturnType};
 
 /// Parses namespace members declaration
 pub type NamespaceMembers = Vec<NamespaceMember>;
 
-/// Parses namespace member declaration
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub enum NamespaceMember {
-    Operation(OperationNamespaceMember),
-    Attribute(AttributeNamespaceMember)
-}
-
-impl Parse for NamespaceMember {
-    named!(parse -> Self, alt!(
-        weedle!(OperationNamespaceMember) => {|inner| NamespaceMember::Operation(inner)} |
-        weedle!(AttributeNamespaceMember) => {|inner| NamespaceMember::Attribute(inner)}
-    ));
-}
-
-/// Parses `[attributes]? returntype identifier? (( args ));`
-///
-/// (( )) means ( ) chars
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct OperationNamespaceMember {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub return_type: ReturnType,
-    pub identifier: Option<Identifier>,
-    pub args: Braced<ArgumentList>,
-    pub semi_colon: term!(;)
-}
-
-impl Parse for OperationNamespaceMember {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        return_type: weedle!(ReturnType) >>
-        identifier: weedle!(Option<Identifier>) >>
-        args: weedle!(Braced<ArgumentList>) >>
-        semi_colon: weedle!(term!(;)) >>
-        (OperationNamespaceMember { attributes, return_type, identifier, args, semi_colon })
-    ));
-}
-
-/// Parses `[attribute]? readonly attributetype type identifier;`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct AttributeNamespaceMember {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub readonly: term!(readonly),
-    pub attribute: term!(attribute),
-    pub type_: AttributedType,
-    pub identifier: Identifier,
-    pub semi_colon: term!(;)
-}
-
-impl Parse for AttributeNamespaceMember {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        readonly: weedle!(term!(readonly)) >>
-        attribute: weedle!(term!(attribute)) >>
-        type_: weedle!(AttributedType) >>
-        identifier: weedle!(Identifier) >>
-        semi_colon: weedle!(term!(;)) >>
-        (AttributeNamespaceMember { attributes, readonly, attribute, type_, identifier, semi_colon })
-    ));
+ast_types! {
+    /// Parses namespace member declaration
+    enum NamespaceMember {
+        /// Parses `[attributes]? returntype identifier? (( args ));`
+        ///
+        /// (( )) means ( ) chars
+        Operation(struct OperationNamespaceMember {
+            attributes: Option<ExtendedAttributeList>,
+            return_type: ReturnType,
+            identifier: Option<Identifier>,
+            args: Braced<ArgumentList>,
+            semi_colon: term!(;),
+        }),
+        /// Parses `[attribute]? readonly attributetype type identifier;`
+        Attribute(struct AttributeNamespaceMember {
+            attributes: Option<ExtendedAttributeList>,
+            readonly: term!(readonly),
+            attribute: term!(attribute),
+            type_: AttributedType,
+            identifier: Identifier,
+            semi_colon: term!(;),
+        }),
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use Parse;
 
     test!(should_parse_attribute_namespace_member { "readonly attribute short name;" =>
         "";
         AttributeNamespaceMember;
         attributes.is_none();
-        identifier.name == "name";
+        identifier.0 == "name";
     });
 
     test!(should_parse_operation_namespace_member { "short (long a, long b);" =>

--- a/src/term.rs
+++ b/src/term.rs
@@ -1,14 +1,8 @@
-use nom::types::CompleteStr;
-
-fn select_first(input: Vec<CompleteStr>) -> CompleteStr {
-    input[0]
-}
-
 macro_rules! generate_terms {
     ($( $(#[$attr:meta])* $typ:ident => $tok:expr ),*) => {
         $(
             $(#[$attr])*
-            #[derive(Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
+            #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
             pub struct $typ;
 
             impl $crate::Parse for $typ {
@@ -21,20 +15,36 @@ macro_rules! generate_terms {
     };
 }
 
+macro_rules! ident_tag (
+    ($i:expr, $tok:expr) => (
+        {
+            match tag!($i, $tok) {
+                Err(e) => Err(e),
+                Ok((i, o)) => {
+                    let mut res = Ok((i, o));
+                    if let Some(&c) = i.as_bytes().first() {
+                        use $crate::nom::{Context, Err, ErrorKind, is_alphanumeric};
+                        if is_alphanumeric(c) || c == b'_' || c == b'-' {
+                            res = Err(Err::Error(Context::Code($i, ErrorKind::Tag::<u32>)));
+                        }
+                    }
+                    res
+                },
+            }
+        }
+    )
+);
+
 macro_rules! generate_terms_for_names {
     ($( $(#[$attr:meta])* $typ:ident => $tok:expr ),*) => {
         $(
             $(#[$attr])*
-            #[derive(Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
+            #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
             pub struct $typ;
 
             impl $crate::Parse for $typ {
                 named!(parse -> Self, do_parse!(
-                    string: map!(
-                        ws!(re_capture_static!(r"^(-?[A-Za-z][0-9A-Za-z]*)")),
-                        select_first
-                    ) >>
-                    err_if_not!(string.0 == $tok) >>
+                    ws!(ident_tag!($tok)) >>
                     ($typ)
                 ));
             }
@@ -43,323 +53,479 @@ macro_rules! generate_terms_for_names {
 }
 
 generate_terms! {
-    #[doc="Represents the terminal symbol `{`"]
+    /// Represents the terminal symbol `{`
     OpenParen => "{",
 
-    #[doc="Represents the terminal symbol `}`"]
+    /// Represents the terminal symbol `}`
     CloseParen => "}",
 
-    #[doc="Represents the terminal symbol `[`"]
+    /// Represents the terminal symbol `[`
     OpenBracket => "[",
 
-    #[doc="Represents the terminal symbol `]`"]
+    /// Represents the terminal symbol `]`
     CloseBracket => "]",
 
-    #[doc="Represents the terminal symbol `(`"]
+    /// Represents the terminal symbol `(`
     OpenBrace => "(",
 
-    #[doc="Represents the terminal symbol `)`"]
+    /// Represents the terminal symbol `)`
     CloseBrace => ")",
 
-    #[doc="Represents the terminal symbol `,`"]
+    /// Represents the terminal symbol `,`
     Comma => ",",
 
-    #[doc="Represents the terminal symbol `-`"]
+    /// Represents the terminal symbol `-`
     Minus => "-",
 
-    #[doc="Represents the terminal symbol `.`"]
+    /// Represents the terminal symbol `.`
     Dot => ".",
 
-    #[doc="Represents the terminal symbol `...`"]
+    /// Represents the terminal symbol `...`
     Ellipsis => "...",
 
-    #[doc="Represents the terminal symbol `:`"]
+    /// Represents the terminal symbol `:`
     Colon => ":",
 
-    #[doc="Represents the terminal symbol `;`"]
+    /// Represents the terminal symbol `;`
     SemiColon => ";",
 
-    #[doc="Represents the terminal symbol `<`"]
+    /// Represents the terminal symbol `<`
     LessThan => "<",
 
-    #[doc="Represents the terminal symbol `=`"]
+    /// Represents the terminal symbol `=`
     Assign => "=",
 
-    #[doc="Represents the terminal symbol `>`"]
+    /// Represents the terminal symbol `>`
     GreaterThan => ">",
 
-    #[doc="Represents the terminal symbol `?`"]
+    /// Represents the terminal symbol `?`
     QMark => "?"
 }
 
 generate_terms_for_names! {
-    #[doc="Represents the terminal symbol `or`"]
+    /// Represents the terminal symbol `or`
     Or => "or",
 
-    #[doc="Represents the terminal symbol `optional`"]
+    /// Represents the terminal symbol `optional`
     Optional => "optional",
 
-    #[doc="Represents the terminal symbol `attribute`"]
+    /// Represents the terminal symbol `attribute`
     Attribute => "attribute",
 
-    #[doc="Represents the terminal symbol `callback`"]
+    /// Represents the terminal symbol `callback`
     Callback => "callback",
 
-    #[doc="Represents the terminal symbol `const`"]
+    /// Represents the terminal symbol `const`
     Const => "const",
 
-    #[doc="Represents the terminal symbol `deleter`"]
+    /// Represents the terminal symbol `deleter`
     Deleter => "deleter",
 
-    #[doc="Represents the terminal symbol `dictionary`"]
+    /// Represents the terminal symbol `dictionary`
     Dictionary => "dictionary",
 
-    #[doc="Represents the terminal symbol `enum`"]
+    /// Represents the terminal symbol `enum`
     Enum => "enum",
 
-    #[doc="Represents the terminal symbol `getter`"]
+    /// Represents the terminal symbol `getter`
     Getter => "getter",
 
-    #[doc="Represents the terminal symbol `includes`"]
+    /// Represents the terminal symbol `includes`
     Includes => "includes",
 
-    #[doc="Represents the terminal symbol `inherit`"]
+    /// Represents the terminal symbol `inherit`
     Inherit => "inherit",
 
-    #[doc="Represents the terminal symbol `interface`"]
+    /// Represents the terminal symbol `interface`
     Interface => "interface",
 
-    #[doc="Represents the terminal symbol `iterable`"]
+    /// Represents the terminal symbol `iterable`
     Iterable => "iterable",
 
-    #[doc="Represents the terminal symbol `maplike`"]
+    /// Represents the terminal symbol `maplike`
     Maplike => "maplike",
 
-    #[doc="Represents the terminal symbol `namespace`"]
+    /// Represents the terminal symbol `namespace`
     Namespace => "namespace",
 
-    #[doc="Represents the terminal symbol `partial`"]
+    /// Represents the terminal symbol `partial`
     Partial => "partial",
 
-    #[doc="Represents the terminal symbol `required`"]
+    /// Represents the terminal symbol `required`
     Required => "required",
 
-    #[doc="Represents the terminal symbol `setlike`"]
+    /// Represents the terminal symbol `setlike`
     Setlike => "setlike",
 
-    #[doc="Represents the terminal symbol `setter`"]
+    /// Represents the terminal symbol `setter`
     Setter => "setter",
 
-    #[doc="Represents the terminal symbol `static`"]
+    /// Represents the terminal symbol `static`
     Static => "static",
 
-    #[doc="Represents the terminal symbol `stringifier`"]
+    /// Represents the terminal symbol `stringifier`
     Stringifier => "stringifier",
 
-    #[doc="Represents the terminal symbol `typedef`"]
+    /// Represents the terminal symbol `typedef`
     Typedef => "typedef",
 
-    #[doc="Represents the terminal symbol `unrestricted`"]
+    /// Represents the terminal symbol `unrestricted`
     Unrestricted => "unrestricted",
 
-    #[doc="Represents the terminal symbol `symbol`"]
+    /// Represents the terminal symbol `symbol`
     Symbol => "symbol",
 
-    #[doc="Represents the terminal symbol `Infinity`"]
+    /// Represents the terminal symbol `Infinity`
     NegInfinity => "-Infinity",
 
-    #[doc="Represents the terminal symbol `ByteString`"]
+    /// Represents the terminal symbol `ByteString`
     ByteString => "ByteString",
 
-    #[doc="Represents the terminal symbol `DOMString`"]
+    /// Represents the terminal symbol `DOMString`
     DOMString => "DOMString",
 
-    #[doc="Represents the terminal symbol `FrozenArray`"]
+    /// Represents the terminal symbol `FrozenArray`
     FrozenArray => "FrozenArray",
 
-    #[doc="Represents the terminal symbol `Infinity`"]
+    /// Represents the terminal symbol `Infinity`
     Infinity => "Infinity",
 
-    #[doc="Represents the terminal symbol `NaN`"]
+    /// Represents the terminal symbol `NaN`
     NaN => "NaN",
 
-    #[doc="Represents the terminal symbol `USVString`"]
+    /// Represents the terminal symbol `USVString`
     USVString => "USVString",
 
-    #[doc="Represents the terminal symbol `any`"]
+    /// Represents the terminal symbol `any`
     Any => "any",
 
-    #[doc="Represents the terminal symbol `boolean`"]
+    /// Represents the terminal symbol `boolean`
     Boolean => "boolean",
 
-    #[doc="Represents the terminal symbol `byte`"]
+    /// Represents the terminal symbol `byte`
     Byte => "byte",
 
-    #[doc="Represents the terminal symbol `double`"]
+    /// Represents the terminal symbol `double`
     Double => "double",
 
-    #[doc="Represents the terminal symbol `false`"]
+    /// Represents the terminal symbol `false`
     False => "false",
 
-    #[doc="Represents the terminal symbol `float`"]
+    /// Represents the terminal symbol `float`
     Float => "float",
 
-    #[doc="Represents the terminal symbol `long`"]
+    /// Represents the terminal symbol `long`
     Long => "long",
 
-    #[doc="Represents the terminal symbol `null`"]
+    /// Represents the terminal symbol `null`
     Null => "null",
 
-    #[doc="Represents the terminal symbol `object`"]
+    /// Represents the terminal symbol `object`
     Object => "object",
 
-    #[doc="Represents the terminal symbol `octet`"]
+    /// Represents the terminal symbol `octet`
     Octet => "octet",
 
-    #[doc="Represents the terminal symbol `sequence`"]
+    /// Represents the terminal symbol `sequence`
     Sequence => "sequence",
 
-    #[doc="Represents the terminal symbol `short`"]
+    /// Represents the terminal symbol `short`
     Short => "short",
 
-    #[doc="Represents the terminal symbol `true`"]
+    /// Represents the terminal symbol `true`
     True => "true",
 
-    #[doc="Represents the terminal symbol `unsigned`"]
+    /// Represents the terminal symbol `unsigned`
     Unsigned => "unsigned",
 
-    #[doc="Represents the terminal symbol `void`"]
+    /// Represents the terminal symbol `void`
     Void => "void",
 
-    #[doc="Represents the terminal symbol `record`"]
+    /// Represents the terminal symbol `record`
     Record => "record",
 
-    #[doc="Represents the terminal symbol `ArrayBuffer`"]
+    /// Represents the terminal symbol `ArrayBuffer`
     ArrayBuffer => "ArrayBuffer",
 
-    #[doc="Represents the terminal symbol `DataView`"]
+    /// Represents the terminal symbol `DataView`
     DataView => "DataView",
 
-    #[doc="Represents the terminal symbol `Int8Array`"]
+    /// Represents the terminal symbol `Int8Array`
     Int8Array => "Int8Array",
 
-    #[doc="Represents the terminal symbol `Int16Array`"]
+    /// Represents the terminal symbol `Int16Array`
     Int16Array => "Int16Array",
 
-    #[doc="Represents the terminal symbol `Int32Array`"]
+    /// Represents the terminal symbol `Int32Array`
     Int32Array => "Int32Array",
 
-    #[doc="Represents the terminal symbol `Uint8Array`"]
+    /// Represents the terminal symbol `Uint8Array`
     Uint8Array => "Uint8Array",
 
-    #[doc="Represents the terminal symbol `Uint16Array`"]
+    /// Represents the terminal symbol `Uint16Array`
     Uint16Array => "Uint16Array",
 
-    #[doc="Represents the terminal symbol `Uint32Array`"]
+    /// Represents the terminal symbol `Uint32Array`
     Uint32Array => "Uint32Array",
 
-    #[doc="Represents the terminal symbol `Uint8ClampedArray`"]
+    /// Represents the terminal symbol `Uint8ClampedArray`
     Uint8ClampedArray => "Uint8ClampedArray",
 
-    #[doc="Represents the terminal symbol `Float32Array`"]
+    /// Represents the terminal symbol `Float32Array`
     Float32Array => "Float32Array",
 
-    #[doc="Represents the terminal symbol `Float64Array`"]
+    /// Represents the terminal symbol `Float64Array`
     Float64Array => "Float64Array",
 
-    #[doc="Represents the terminal symbol `Promise`"]
+    /// Represents the terminal symbol `Promise`
     Promise => "Promise",
 
-    #[doc="Represents the terminal symbol `Error`"]
+    /// Represents the terminal symbol `Error`
     Error => "Error",
 
-    #[doc="Represents the terminal symbol `readonly`"]
+    /// Represents the terminal symbol `readonly`
     ReadOnly => "readonly",
 
-    #[doc="Represents the terminal symbol `mixin`"]
+    /// Represents the terminal symbol `mixin`
     Mixin => "mixin"
 }
 
 #[macro_export]
 macro_rules! term {
-    (OpenParen) => { $crate::term::OpenParen };
-    (CloseParen) => { $crate::term::CloseParen };
-    (OpenBracket) => { $crate::term::OpenBracket };
-    (CloseBracket) => { $crate::term::CloseBracket };
-    (OpenBrace) => { $crate::term::OpenBrace };
-    (CloseBrace) => { $crate::term::CloseBrace };
-    (,) => { $crate::term::Comma };
-    (-) => { $crate::term::Minus };
-    (.) => { $crate::term::Dot };
-    (...) => { $crate::term::Ellipsis };
-    (:) => { $crate::term::Colon };
-    (;) => { $crate::term::SemiColon };
-    (<) => { $crate::term::LessThan };
-    (=) => { $crate::term::Assign };
-    (>) => { $crate::term::GreaterThan };
-    (?) => { $crate::term::QMark };
-    (or) => { $crate::term::Or };
-    (optional) => { $crate::term::Optional };
-    (attribute) => { $crate::term::Attribute };
-    (callback) => { $crate::term::Callback };
-    (const) => { $crate::term::Const };
-    (deleter) => { $crate::term::Deleter };
-    (dictionary) => { $crate::term::Dictionary };
-    (enum) => { $crate::term::Enum };
-    (getter) => { $crate::term::Getter };
-    (includes) => { $crate::term::Includes };
-    (inherit) => { $crate::term::Inherit };
-    (interface) => { $crate::term::Interface };
-    (iterable) => { $crate::term::Iterable };
-    (maplike) => { $crate::term::Maplike };
-    (namespace) => { $crate::term::Namespace };
-    (partial) => { $crate::term::Partial };
-    (required) => { $crate::term::Required };
-    (setlike) => { $crate::term::Setlike };
-    (setter) => { $crate::term::Setter };
-    (static) => { $crate::term::Static };
-    (stringifier) => { $crate::term::Stringifier };
-    (typedef) => { $crate::term::Typedef };
-    (unrestricted) => { $crate::term::Unrestricted };
-    (symbol) => { $crate::term::Symbol };
-    (-Infinity) => { $crate::term::NegInfinity };
-    (ByteString) => { $crate::term::ByteString };
-    (DOMString) => { $crate::term::DOMString };
-    (FrozenArray) => { $crate::term::FrozenArray };
-    (Infinity) => { $crate::term::Infinity };
-    (NaN) => { $crate::term::NaN };
-    (USVString) => { $crate::term::USVString };
-    (any) => { $crate::term::Any };
-    (boolean) => { $crate::term::Boolean };
-    (byte) => { $crate::term::Byte };
-    (double) => { $crate::term::Double };
-    (false) => { $crate::term::False };
-    (float) => { $crate::term::Float };
-    (long) => { $crate::term::Long };
-    (null) => { $crate::term::Null };
-    (object) => { $crate::term::Object };
-    (octet) => { $crate::term::Octet };
-    (sequence) => { $crate::term::Sequence };
-    (short) => { $crate::term::Short };
-    (true) => { $crate::term::True };
-    (unsigned) => { $crate::term::Unsigned };
-    (void) => { $crate::term::Void };
-    (record) => { $crate::term::Record };
-    (ArrayBuffer) => { $crate::term::ArrayBuffer };
-    (DataView) => { $crate::term::DataView };
-    (Int8Array) => { $crate::term::Int8Array };
-    (Int16Array) => { $crate::term::Int16Array };
-    (Int32Array) => { $crate::term::Int32Array };
-    (Uint8Array) => { $crate::term::Uint8Array };
-    (Uint16Array) => { $crate::term::Uint16Array };
-    (Uint32Array) => { $crate::term::Uint32Array };
-    (Uint8ClampedArray) => { $crate::term::Uint8ClampedArray };
-    (Float32Array) => { $crate::term::Float32Array };
-    (Float64Array) => { $crate::term::Float64Array };
-    (Promise) => { $crate::term::Promise };
-    (Error) => { $crate::term::Error };
-    (readonly) => { $crate::term::ReadOnly };
-    (mixin) => { $crate::term::Mixin };
+    (OpenParen) => {
+        $crate::term::OpenParen
+    };
+    (CloseParen) => {
+        $crate::term::CloseParen
+    };
+    (OpenBracket) => {
+        $crate::term::OpenBracket
+    };
+    (CloseBracket) => {
+        $crate::term::CloseBracket
+    };
+    (OpenBrace) => {
+        $crate::term::OpenBrace
+    };
+    (CloseBrace) => {
+        $crate::term::CloseBrace
+    };
+    (,) => {
+        $crate::term::Comma
+    };
+    (-) => {
+        $crate::term::Minus
+    };
+    (.) => {
+        $crate::term::Dot
+    };
+    (...) => {
+        $crate::term::Ellipsis
+    };
+    (:) => {
+        $crate::term::Colon
+    };
+    (;) => {
+        $crate::term::SemiColon
+    };
+    (<) => {
+        $crate::term::LessThan
+    };
+    (=) => {
+        $crate::term::Assign
+    };
+    (>) => {
+        $crate::term::GreaterThan
+    };
+    (?) => {
+        $crate::term::QMark
+    };
+    (or) => {
+        $crate::term::Or
+    };
+    (optional) => {
+        $crate::term::Optional
+    };
+    (attribute) => {
+        $crate::term::Attribute
+    };
+    (callback) => {
+        $crate::term::Callback
+    };
+    (const) => {
+        $crate::term::Const
+    };
+    (deleter) => {
+        $crate::term::Deleter
+    };
+    (dictionary) => {
+        $crate::term::Dictionary
+    };
+    (enum) => {
+        $crate::term::Enum
+    };
+    (getter) => {
+        $crate::term::Getter
+    };
+    (includes) => {
+        $crate::term::Includes
+    };
+    (inherit) => {
+        $crate::term::Inherit
+    };
+    (interface) => {
+        $crate::term::Interface
+    };
+    (iterable) => {
+        $crate::term::Iterable
+    };
+    (maplike) => {
+        $crate::term::Maplike
+    };
+    (namespace) => {
+        $crate::term::Namespace
+    };
+    (partial) => {
+        $crate::term::Partial
+    };
+    (required) => {
+        $crate::term::Required
+    };
+    (setlike) => {
+        $crate::term::Setlike
+    };
+    (setter) => {
+        $crate::term::Setter
+    };
+    (static) => {
+        $crate::term::Static
+    };
+    (stringifier) => {
+        $crate::term::Stringifier
+    };
+    (typedef) => {
+        $crate::term::Typedef
+    };
+    (unrestricted) => {
+        $crate::term::Unrestricted
+    };
+    (symbol) => {
+        $crate::term::Symbol
+    };
+    (- Infinity) => {
+        $crate::term::NegInfinity
+    };
+    (ByteString) => {
+        $crate::term::ByteString
+    };
+    (DOMString) => {
+        $crate::term::DOMString
+    };
+    (FrozenArray) => {
+        $crate::term::FrozenArray
+    };
+    (Infinity) => {
+        $crate::term::Infinity
+    };
+    (NaN) => {
+        $crate::term::NaN
+    };
+    (USVString) => {
+        $crate::term::USVString
+    };
+    (any) => {
+        $crate::term::Any
+    };
+    (boolean) => {
+        $crate::term::Boolean
+    };
+    (byte) => {
+        $crate::term::Byte
+    };
+    (double) => {
+        $crate::term::Double
+    };
+    (false) => {
+        $crate::term::False
+    };
+    (float) => {
+        $crate::term::Float
+    };
+    (long) => {
+        $crate::term::Long
+    };
+    (null) => {
+        $crate::term::Null
+    };
+    (object) => {
+        $crate::term::Object
+    };
+    (octet) => {
+        $crate::term::Octet
+    };
+    (sequence) => {
+        $crate::term::Sequence
+    };
+    (short) => {
+        $crate::term::Short
+    };
+    (true) => {
+        $crate::term::True
+    };
+    (unsigned) => {
+        $crate::term::Unsigned
+    };
+    (void) => {
+        $crate::term::Void
+    };
+    (record) => {
+        $crate::term::Record
+    };
+    (ArrayBuffer) => {
+        $crate::term::ArrayBuffer
+    };
+    (DataView) => {
+        $crate::term::DataView
+    };
+    (Int8Array) => {
+        $crate::term::Int8Array
+    };
+    (Int16Array) => {
+        $crate::term::Int16Array
+    };
+    (Int32Array) => {
+        $crate::term::Int32Array
+    };
+    (Uint8Array) => {
+        $crate::term::Uint8Array
+    };
+    (Uint16Array) => {
+        $crate::term::Uint16Array
+    };
+    (Uint32Array) => {
+        $crate::term::Uint32Array
+    };
+    (Uint8ClampedArray) => {
+        $crate::term::Uint8ClampedArray
+    };
+    (Float32Array) => {
+        $crate::term::Float32Array
+    };
+    (Float64Array) => {
+        $crate::term::Float64Array
+    };
+    (Promise) => {
+        $crate::term::Promise
+    };
+    (Error) => {
+        $crate::term::Error
+    };
+    (readonly) => {
+        $crate::term::ReadOnly
+    };
+    (mixin) => {
+        $crate::term::Mixin
+    };
 }
 
 #[cfg(test)]

--- a/src/term.rs
+++ b/src/term.rs
@@ -5,8 +5,8 @@ macro_rules! generate_terms {
             #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
             pub struct $typ;
 
-            impl $crate::Parse for $typ {
-                named!(parse -> Self, do_parse!(
+            impl<'a> $crate::Parse<'a> for $typ {
+                parser!(do_parse!(
                     ws!(tag!($tok)) >>
                     ($typ)
                 ));
@@ -42,8 +42,8 @@ macro_rules! generate_terms_for_names {
             #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
             pub struct $typ;
 
-            impl $crate::Parse for $typ {
-                named!(parse -> Self, do_parse!(
+            impl<'a> $crate::Parse<'a> for $typ {
+                parser!(do_parse!(
                     ws!(ident_tag!($tok)) >>
                     ($typ)
                 ));

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,416 +1,184 @@
-use attribute::*;
-use common::*;
-use Parse;
+use attribute::ExtendedAttributeList;
+use common::{Braced, Generics, Identifier, Punctuated};
 use term;
-
-/// Parses either single type or a union type
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub enum Type {
-    Single(SingleType),
-    Union(MayBeNull<UnionType>),
-}
-
-impl Parse for Type {
-    named!(parse -> Self, alt_complete!(
-        weedle!(SingleType) => {|inner| Type::Single(inner)} |
-        weedle!(MayBeNull<UnionType>) => {|inner| Type::Union(inner)}
-    ));
-}
-
-/// Parses one of the single types
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub enum SingleType {
-    Any(term!(any)),
-    Promise(PromiseType),
-    Integer(MayBeNull<IntegerType>),
-    FloatingPoint(MayBeNull<FloatingPointType>),
-    Boolean(MayBeNull<term!(boolean)>),
-    Byte(MayBeNull<term!(byte)>),
-    Octet(MayBeNull<term!(octet)>),
-    ByteString(MayBeNull<term!(ByteString)>),
-    DOMString(MayBeNull<term!(DOMString)>),
-    USVString(MayBeNull<term!(USVString)>),
-    Sequence(MayBeNull<SequenceType>),
-    Object(MayBeNull<term!(object)>),
-    Symbol(MayBeNull<term!(symbol)>),
-    Error(MayBeNull<term!(Error)>),
-    ArrayBuffer(MayBeNull<term!(ArrayBuffer)>),
-    DataView(MayBeNull<term!(DataView)>),
-    Int8Array(MayBeNull<term!(Int8Array)>),
-    Int16Array(MayBeNull<term!(Int16Array)>),
-    Int32Array(MayBeNull<term!(Int32Array)>),
-    Uint8Array(MayBeNull<term!(Uint8Array)>),
-    Uint16Array(MayBeNull<term!(Uint16Array)>),
-    Uint32Array(MayBeNull<term!(Uint32Array)>),
-    Uint8ClampedArray(MayBeNull<term!(Uint8ClampedArray)>),
-    Float32Array(MayBeNull<term!(Float32Array)>),
-    Float64Array(MayBeNull<term!(Float64Array)>),
-    FrozenArrayType(MayBeNull<FrozenArrayType>),
-    RecordType(MayBeNull<RecordType>),
-    Identifier(MayBeNull<Identifier>),
-}
-
-impl Parse for SingleType {
-    named!(parse -> Self, alt!(
-        weedle!(term!(any)) => {|inner| SingleType::Any(inner)} |
-        weedle!(PromiseType) => {|inner| SingleType::Promise(inner)} |
-        weedle!(MayBeNull<IntegerType>) => {|inner| SingleType::Integer(inner)} |
-        weedle!(MayBeNull<FloatingPointType>) => {|inner| SingleType::FloatingPoint(inner)} |
-        weedle!(MayBeNull<term!(boolean)>) => {|inner| SingleType::Boolean(inner)} |
-        weedle!(MayBeNull<term!(byte)>) => {|inner| SingleType::Byte(inner)} |
-        weedle!(MayBeNull<term!(octet)>) => {|inner| SingleType::Octet(inner)} |
-        weedle!(MayBeNull<term!(ByteString)>) => {|inner| SingleType::ByteString(inner)} |
-        weedle!(MayBeNull<term!(DOMString)>) => {|inner| SingleType::DOMString(inner)} |
-        weedle!(MayBeNull<term!(USVString)>) => {|inner| SingleType::USVString(inner)} |
-        weedle!(MayBeNull<SequenceType>) => {|inner| SingleType::Sequence(inner)} |
-        weedle!(MayBeNull<term!(object)>) => {|inner| SingleType::Object(inner)} |
-        weedle!(MayBeNull<term!(symbol)>) => {|inner| SingleType::Symbol(inner)} |
-        weedle!(MayBeNull<term!(Error)>) => {|inner| SingleType::Error(inner)} |
-        weedle!(MayBeNull<term!(ArrayBuffer)>) => {|inner| SingleType::ArrayBuffer(inner)} |
-        weedle!(MayBeNull<term!(DataView)>) => {|inner| SingleType::DataView(inner)} |
-        weedle!(MayBeNull<term!(Int8Array)>) => {|inner| SingleType::Int8Array(inner)} |
-        weedle!(MayBeNull<term!(Int16Array)>) => {|inner| SingleType::Int16Array(inner)} |
-        weedle!(MayBeNull<term!(Int32Array)>) => {|inner| SingleType::Int32Array(inner)} |
-        weedle!(MayBeNull<term!(Uint8Array)>) => {|inner| SingleType::Uint8Array(inner)} |
-        weedle!(MayBeNull<term!(Uint16Array)>) => {|inner| SingleType::Uint16Array(inner)} |
-        weedle!(MayBeNull<term!(Uint32Array)>) => {|inner| SingleType::Uint32Array(inner)} |
-        weedle!(MayBeNull<term!(Uint8ClampedArray)>) => {|inner| SingleType::Uint8ClampedArray(inner)} |
-        weedle!(MayBeNull<term!(Float32Array)>) => {|inner| SingleType::Float32Array(inner)} |
-        weedle!(MayBeNull<term!(Float64Array)>) => {|inner| SingleType::Float64Array(inner)} |
-        weedle!(MayBeNull<FrozenArrayType>) => {|inner| SingleType::FrozenArrayType(inner)} |
-        weedle!(MayBeNull<RecordType>) => {|inner| SingleType::RecordType(inner)} |
-        weedle!(MayBeNull<Identifier>) => {|inner| SingleType::Identifier(inner)}
-    ));
-}
-
-/// Parses `sequence<Type>`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct SequenceType {
-    pub sequence: term!(sequence),
-    pub generics: Generics<Box<Type>>,
-}
-
-impl Parse for SequenceType {
-    named!(parse -> Self, do_parse!(
-        sequence: weedle!(term!(sequence)) >>
-        generics: weedle!(Generics<Box<Type>>) >>
-        (SequenceType { sequence, generics })
-    ));
-}
-
-/// Parses `FrozenArray<Type>`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct FrozenArrayType {
-    pub frozen_array: term!(FrozenArray),
-    pub generics: Generics<Box<Type>>,
-}
-
-impl Parse for FrozenArrayType {
-    named!(parse -> Self, do_parse!(
-        frozen_array: weedle!(term!(FrozenArray)) >>
-        generics: weedle!(Generics<Box<Type>>) >>
-        (FrozenArrayType { frozen_array, generics })
-    ));
-}
-
-/// Parses a nullable type. Ex: `object | object??`
-///
-/// `??` means an actual ? not an optional requirement
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct MayBeNull<T> {
-    pub type_: T,
-    pub q_mark: Option<term::QMark>,
-}
-
-impl<T: Parse> Parse for MayBeNull<T> {
-    named!(parse -> Self, do_parse!(
-        type_: weedle!(T) >>
-        q_mark: weedle!(Option<term!(?)>) >>
-        (MayBeNull { type_, q_mark })
-    ));
-}
-
-/// Parses a `Promise<Type|void>` type
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct PromiseType {
-    pub promise: term!(Promise),
-    pub generics: Generics<Box<ReturnType>>,
-}
-
-impl Parse for PromiseType {
-    named!(parse -> Self, do_parse!(
-        promise: weedle!(term!(Promise)) >>
-        generics: weedle!(Generics<Box<ReturnType>>) >>
-        (PromiseType { promise, generics })
-    ));
-}
-
-/// Parses `unsigned? short|long|(long long)`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub enum IntegerType {
-    Short(ShortType),
-    LongLong(LongLongType),
-    Long(LongType),
-}
-
-impl Parse for IntegerType {
-    named!(parse -> Self, alt!(
-        weedle!(ShortType) => {|inner| IntegerType::Short(inner)} |
-        weedle!(LongLongType) => {|inner| IntegerType::LongLong(inner)} |
-        weedle!(LongType) => {|inner| IntegerType::Long(inner)}
-    ));
-}
-
-/// Parses `unsigned? short`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct ShortType {
-    pub unsigned: Option<term!(unsigned)>,
-    pub short: term!(short)
-}
-
-impl Parse for ShortType {
-    named!(parse -> Self, do_parse!(
-        unsigned: weedle!(Option<term!(unsigned)>) >>
-        short: weedle!(term!(short)) >>
-        (ShortType { unsigned, short })
-    ));
-}
-
-/// Parses `unsigned? long`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct LongType {
-    pub unsigned: Option<term!(unsigned)>,
-    pub long: term!(long)
-}
-
-impl Parse for LongType {
-    named!(parse -> Self, do_parse!(
-        unsigned: weedle!(Option<term!(unsigned)>) >>
-        long: weedle!(term!(long)) >>
-        (LongType { unsigned, long })
-    ));
-}
-
-/// Parses `unsigned? long long`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct LongLongType {
-    pub unsigned: Option<term!(unsigned)>,
-    pub long_long: (term!(long), term!(long))
-}
-
-impl Parse for LongLongType {
-    named!(parse -> Self, do_parse!(
-        unsigned: weedle!(Option<term!(unsigned)>) >>
-        long_long: weedle!((term!(long), term!(long))) >>
-        (LongLongType { unsigned, long_long })
-    ));
-}
-
-/// Parses `unrestricted? float|double`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub enum FloatingPointType {
-    Float(FloatType),
-    Double(DoubleType),
-}
-
-impl Parse for FloatingPointType {
-    named!(parse -> Self, alt!(
-        weedle!(FloatType) => {|inner| FloatingPointType::Float(inner)} |
-        weedle!(DoubleType) => {|inner| FloatingPointType::Double(inner)}
-    ));
-}
-
-/// Parses `unrestricted? float`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct FloatType {
-    pub unrestricted: Option<term!(unrestricted)>,
-    pub float: term!(float)
-}
-
-impl Parse for FloatType {
-    named!(parse -> Self, do_parse!(
-        unrestricted: weedle!(Option<term!(unrestricted)>) >>
-        float: weedle!(term!(float)) >>
-        (FloatType { unrestricted, float })
-    ));
-}
-
-/// Parses `unrestricted? double`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct DoubleType {
-    pub unrestricted: Option<term!(unrestricted)>,
-    pub double: term!(double)
-}
-
-impl Parse for DoubleType {
-    named!(parse -> Self, do_parse!(
-        unrestricted: weedle!(Option<term!(unrestricted)>) >>
-        double: weedle!(term!(double)) >>
-        (DoubleType { unrestricted, double })
-    ));
-}
-
-/// Parses `record<StringType, Type>`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct RecordType {
-    pub record: term!(record),
-    pub generics: Generics<(StringType, term!(,), Box<Type>)>,
-}
-
-impl Parse for RecordType {
-    named!(parse -> Self, do_parse!(
-        record: weedle!(term!(record)) >>
-        generics: weedle!(Generics<(StringType, term!(,), Box<Type>)>) >>
-        (RecordType { record, generics })
-    ));
-}
-
-/// Parses one of the string types `ByteString|DOMString|USVString`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub enum StringType {
-    Byte(term!(ByteString)),
-    DOM(term!(DOMString)),
-    USV(term!(USVString)),
-}
-
-impl Parse for StringType {
-    named!(parse -> Self, alt!(
-        weedle!(term!(ByteString)) => {|inner| StringType::Byte(inner)} |
-        weedle!(term!(DOMString)) => {|inner| StringType::DOM(inner)} |
-        weedle!(term!(USVString)) => {|inner| StringType::USV(inner)}
-    ));
-}
+use Parse;
 
 /// Parses a union of types
 pub type UnionType = Braced<Punctuated<UnionMemberType, term!(or)>>;
 
-/// Parses one of the member of a union type
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub enum UnionMemberType {
-    Single(UnionSingleType),
-    Union(MayBeNull<UnionType>),
-}
+ast_types! {
+    /// Parses either single type or a union type
+    enum Type {
+        /// Parses one of the single types
+        Single(enum SingleType {
+            Any(term!(any)),
+            Promise(PromiseType),
+            Integer(MayBeNull<IntegerType>),
+            FloatingPoint(MayBeNull<FloatingPointType>),
+            Boolean(MayBeNull<term!(boolean)>),
+            Byte(MayBeNull<term!(byte)>),
+            Octet(MayBeNull<term!(octet)>),
+            ByteString(MayBeNull<term!(ByteString)>),
+            DOMString(MayBeNull<term!(DOMString)>),
+            USVString(MayBeNull<term!(USVString)>),
+            Sequence(MayBeNull<SequenceType>),
+            Object(MayBeNull<term!(object)>),
+            Symbol(MayBeNull<term!(symbol)>),
+            Error(MayBeNull<term!(Error)>),
+            ArrayBuffer(MayBeNull<term!(ArrayBuffer)>),
+            DataView(MayBeNull<term!(DataView)>),
+            Int8Array(MayBeNull<term!(Int8Array)>),
+            Int16Array(MayBeNull<term!(Int16Array)>),
+            Int32Array(MayBeNull<term!(Int32Array)>),
+            Uint8Array(MayBeNull<term!(Uint8Array)>),
+            Uint16Array(MayBeNull<term!(Uint16Array)>),
+            Uint32Array(MayBeNull<term!(Uint32Array)>),
+            Uint8ClampedArray(MayBeNull<term!(Uint8ClampedArray)>),
+            Float32Array(MayBeNull<term!(Float32Array)>),
+            Float64Array(MayBeNull<term!(Float64Array)>),
+            FrozenArrayType(MayBeNull<FrozenArrayType>),
+            RecordType(MayBeNull<RecordType>),
+            Identifier(MayBeNull<Identifier>),
+        }),
+        Union(MayBeNull<UnionType>),
+    }
 
-impl Parse for UnionMemberType {
-    named!(parse -> Self, alt!(
-        weedle!(UnionSingleType) => {|inner| UnionMemberType::Single(inner)} |
-        weedle!(MayBeNull<UnionType>) => {|inner| UnionMemberType::Union(inner)}
-    ));
-}
+    /// Parses `sequence<Type>`
+    struct SequenceType {
+        sequence: term!(sequence),
+        generics: Generics<Box<Type>>,
+    }
 
-/// Parses one of the types
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub enum UnionSingleType {
-    Promise(PromiseType),
-    Integer(MayBeNull<IntegerType>),
-    FloatingPoint(MayBeNull<FloatingPointType>),
-    Boolean(MayBeNull<term!(boolean)>),
-    Byte(MayBeNull<term!(byte)>),
-    Octet(MayBeNull<term!(octet)>),
-    ByteString(MayBeNull<term!(ByteString)>),
-    DOMString(MayBeNull<term!(DOMString)>),
-    USVString(MayBeNull<term!(USVString)>),
-    Sequence(MayBeNull<SequenceType>),
-    Object(MayBeNull<term!(object)>),
-    Symbol(MayBeNull<term!(symbol)>),
-    Error(MayBeNull<term!(Error)>),
-    ArrayBuffer(MayBeNull<term!(ArrayBuffer)>),
-    DataView(MayBeNull<term!(DataView)>),
-    Int8Array(MayBeNull<term!(Int8Array)>),
-    Int16Array(MayBeNull<term!(Int16Array)>),
-    Int32Array(MayBeNull<term!(Int32Array)>),
-    Uint8Array(MayBeNull<term!(Uint8Array)>),
-    Uint16Array(MayBeNull<term!(Uint16Array)>),
-    Uint32Array(MayBeNull<term!(Uint32Array)>),
-    Uint8ClampedArray(MayBeNull<term!(Uint8ClampedArray)>),
-    Float32Array(MayBeNull<term!(Float32Array)>),
-    Float64Array(MayBeNull<term!(Float64Array)>),
-    FrozenArrayType(MayBeNull<FrozenArrayType>),
-    RecordType(MayBeNull<RecordType>),
-    Identifier(MayBeNull<Identifier>),
-}
+    /// Parses `FrozenArray<Type>`
+    struct FrozenArrayType {
+        frozen_array: term!(FrozenArray),
+        generics: Generics<Box<Type>>,
+    }
 
-impl Parse for UnionSingleType {
-    named!(parse -> Self, alt!(
-        weedle!(PromiseType) => {|inner| UnionSingleType::Promise(inner)} |
-        weedle!(MayBeNull<IntegerType>) => {|inner| UnionSingleType::Integer(inner)} |
-        weedle!(MayBeNull<FloatingPointType>) => {|inner| UnionSingleType::FloatingPoint(inner)} |
-        weedle!(MayBeNull<term!(boolean)>) => {|inner| UnionSingleType::Boolean(inner)} |
-        weedle!(MayBeNull<term!(byte)>) => {|inner| UnionSingleType::Byte(inner)} |
-        weedle!(MayBeNull<term!(octet)>) => {|inner| UnionSingleType::Octet(inner)} |
-        weedle!(MayBeNull<term!(ByteString)>) => {|inner| UnionSingleType::ByteString(inner)} |
-        weedle!(MayBeNull<term!(DOMString)>) => {|inner| UnionSingleType::DOMString(inner)} |
-        weedle!(MayBeNull<term!(USVString)>) => {|inner| UnionSingleType::USVString(inner)} |
-        weedle!(MayBeNull<SequenceType>) => {|inner| UnionSingleType::Sequence(inner)} |
-        weedle!(MayBeNull<term!(object)>) => {|inner| UnionSingleType::Object(inner)} |
-        weedle!(MayBeNull<term!(symbol)>) => {|inner| UnionSingleType::Symbol(inner)} |
-        weedle!(MayBeNull<term!(Error)>) => {|inner| UnionSingleType::Error(inner)} |
-        weedle!(MayBeNull<term!(ArrayBuffer)>) => {|inner| UnionSingleType::ArrayBuffer(inner)} |
-        weedle!(MayBeNull<term!(DataView)>) => {|inner| UnionSingleType::DataView(inner)} |
-        weedle!(MayBeNull<term!(Int8Array)>) => {|inner| UnionSingleType::Int8Array(inner)} |
-        weedle!(MayBeNull<term!(Int16Array)>) => {|inner| UnionSingleType::Int16Array(inner)} |
-        weedle!(MayBeNull<term!(Int32Array)>) => {|inner| UnionSingleType::Int32Array(inner)} |
-        weedle!(MayBeNull<term!(Uint8Array)>) => {|inner| UnionSingleType::Uint8Array(inner)} |
-        weedle!(MayBeNull<term!(Uint16Array)>) => {|inner| UnionSingleType::Uint16Array(inner)} |
-        weedle!(MayBeNull<term!(Uint32Array)>) => {|inner| UnionSingleType::Uint32Array(inner)} |
-        weedle!(MayBeNull<term!(Uint8ClampedArray)>) => {|inner| UnionSingleType::Uint8ClampedArray(inner)} |
-        weedle!(MayBeNull<term!(Float32Array)>) => {|inner| UnionSingleType::Float32Array(inner)} |
-        weedle!(MayBeNull<term!(Float64Array)>) => {|inner| UnionSingleType::Float64Array(inner)} |
-        weedle!(MayBeNull<FrozenArrayType>) => {|inner| UnionSingleType::FrozenArrayType(inner)} |
-        weedle!(MayBeNull<RecordType>) => {|inner| UnionSingleType::RecordType(inner)} |
-        weedle!(MayBeNull<Identifier>) => {|inner| UnionSingleType::Identifier(inner)}
-    ));
-}
+    /// Parses a nullable type. Ex: `object | object??`
+    ///
+    /// `??` means an actual ? not an optional requirement
+    #[derive(Copy)]
+    struct MayBeNull(T) where [T: Parse] {
+        type_: T,
+        q_mark: Option<term::QMark>,
+    }
 
-/// Parses a const type
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub enum ConstType {
-    Integer(MayBeNull<IntegerType>),
-    FloatingPoint(MayBeNull<FloatingPointType>),
-    Boolean(MayBeNull<term!(boolean)>),
-    Byte(MayBeNull<term!(byte)>),
-    Octet(MayBeNull<term!(octet)>),
-    Identifier(MayBeNull<Identifier>)
-}
+    /// Parses a `Promise<Type|void>` type
+    struct PromiseType {
+        promise: term!(Promise),
+        generics: Generics<Box<ReturnType>>,
+    }
 
-impl Parse for ConstType {
-    named!(parse -> Self, alt!(
-        weedle!(MayBeNull<IntegerType>) => {|inner| ConstType::Integer(inner)} |
-        weedle!(MayBeNull<FloatingPointType>) => {|inner| ConstType::FloatingPoint(inner)} |
-        weedle!(MayBeNull<term!(boolean)>) => {|inner| ConstType::Boolean(inner)} |
-        weedle!(MayBeNull<term!(byte)>) => {|inner| ConstType::Byte(inner)} |
-        weedle!(MayBeNull<term!(octet)>) => {|inner| ConstType::Octet(inner)} |
-        weedle!(MayBeNull<Identifier>) => {|inner| ConstType::Identifier(inner)}
-    ));
-}
+    /// Parses `unsigned? short|long|(long long)`
+    #[derive(Copy)]
+    enum IntegerType {
+        /// Parses `unsigned? long long`
+        #[derive(Copy)]
+        LongLong(struct LongLongType {
+            unsigned: Option<term!(unsigned)>,
+            long_long: (term!(long), term!(long)),
+        }),
+        /// Parses `unsigned? long`
+        #[derive(Copy)]
+        Long(struct LongType {
+            unsigned: Option<term!(unsigned)>,
+            long: term!(long),
+        }),
+        /// Parses `unsigned? short`
+        #[derive(Copy)]
+        Short(struct ShortType {
+            unsigned: Option<term!(unsigned)>,
+            short: term!(short),
+        }),
+    }
 
-/// Parses the return type which may be `void` or any given Type
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub enum ReturnType {
-    Void(term!(void)),
-    Type(Type),
-}
+    /// Parses `unrestricted? float|double`
+    #[derive(Copy)]
+    enum FloatingPointType {
+        /// Parses `unrestricted? float`
+        #[derive(Copy)]
+        Float(struct FloatType {
+            unrestricted: Option<term!(unrestricted)>,
+            float: term!(float),
+        }),
+        /// Parses `unrestricted? double`
+        #[derive(Copy)]
+        Double(struct DoubleType {
+            unrestricted: Option<term!(unrestricted)>,
+            double: term!(double),
+        }),
+    }
 
-impl Parse for ReturnType {
-    named!(parse -> Self, alt_complete!(
-        weedle!(term!(void)) => {|inner| ReturnType::Void(inner)} |
-        weedle!(Type) => {|inner| ReturnType::Type(inner)}
-    ));
-}
+    /// Parses `record<StringType, Type>`
+    struct RecordType {
+        record: term!(record),
+        generics: Generics<(StringType, term!(,), Box<Type>)>,
+    }
 
-/// Parses `[attributes]? type`
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct AttributedType {
-    pub attributes: Option<ExtendedAttributeList>,
-    pub type_: Type
-}
+    /// Parses one of the string types `ByteString|DOMString|USVString`
+    enum StringType {
+        Byte(term!(ByteString)),
+        DOM(term!(DOMString)),
+        USV(term!(USVString)),
+    }
 
-impl Parse for AttributedType {
-    named!(parse -> Self, do_parse!(
-        attributes: weedle!(Option<ExtendedAttributeList>) >>
-        type_: weedle!(Type) >>
-        (AttributedType { attributes, type_ })
-    ));
+    /// Parses one of the member of a union type
+    enum UnionMemberType {
+        /// Parses one of the types
+        Single(enum UnionSingleType {
+            Promise(PromiseType),
+            Integer(MayBeNull<IntegerType>),
+            FloatingPoint(MayBeNull<FloatingPointType>),
+            Boolean(MayBeNull<term!(boolean)>),
+            Byte(MayBeNull<term!(byte)>),
+            Octet(MayBeNull<term!(octet)>),
+            ByteString(MayBeNull<term!(ByteString)>),
+            DOMString(MayBeNull<term!(DOMString)>),
+            USVString(MayBeNull<term!(USVString)>),
+            Sequence(MayBeNull<SequenceType>),
+            Object(MayBeNull<term!(object)>),
+            Symbol(MayBeNull<term!(symbol)>),
+            Error(MayBeNull<term!(Error)>),
+            ArrayBuffer(MayBeNull<term!(ArrayBuffer)>),
+            DataView(MayBeNull<term!(DataView)>),
+            Int8Array(MayBeNull<term!(Int8Array)>),
+            Int16Array(MayBeNull<term!(Int16Array)>),
+            Int32Array(MayBeNull<term!(Int32Array)>),
+            Uint8Array(MayBeNull<term!(Uint8Array)>),
+            Uint16Array(MayBeNull<term!(Uint16Array)>),
+            Uint32Array(MayBeNull<term!(Uint32Array)>),
+            Uint8ClampedArray(MayBeNull<term!(Uint8ClampedArray)>),
+            Float32Array(MayBeNull<term!(Float32Array)>),
+            Float64Array(MayBeNull<term!(Float64Array)>),
+            FrozenArrayType(MayBeNull<FrozenArrayType>),
+            RecordType(MayBeNull<RecordType>),
+            Identifier(MayBeNull<Identifier>),
+        }),
+        Union(MayBeNull<UnionType>),
+    }
+
+    /// Parses a const type
+    enum ConstType {
+        Integer(MayBeNull<IntegerType>),
+        FloatingPoint(MayBeNull<FloatingPointType>),
+        Boolean(MayBeNull<term!(boolean)>),
+        Byte(MayBeNull<term!(byte)>),
+        Octet(MayBeNull<term!(octet)>),
+        Identifier(MayBeNull<Identifier>),
+    }
+
+    /// Parses the return type which may be `void` or any given Type
+    enum ReturnType {
+        Void(term!(void)),
+        Type(Type),
+    }
+
+    /// Parses `[attributes]? type`
+    struct AttributedType {
+        attributes: Option<ExtendedAttributeList>,
+        type_: Type,
+    }
 }
 
 #[cfg(test)]
@@ -520,7 +288,6 @@ mod test {
         "";
         LongLongType;
     });
-
 
     test!(should_parse_long_type { "long" =>
         "";

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,35 +12,40 @@ ast_types! {
         /// Parses one of the single types
         Single(enum SingleType<'a> {
             Any(term!(any)),
-            Promise(PromiseType<'a>),
-            Integer(MayBeNull<IntegerType>),
-            FloatingPoint(MayBeNull<FloatingPointType>),
-            Boolean(MayBeNull<term!(boolean)>),
-            Byte(MayBeNull<term!(byte)>),
-            Octet(MayBeNull<term!(octet)>),
-            ByteString(MayBeNull<term!(ByteString)>),
-            DOMString(MayBeNull<term!(DOMString)>),
-            USVString(MayBeNull<term!(USVString)>),
-            Sequence(MayBeNull<SequenceType<'a>>),
-            Object(MayBeNull<term!(object)>),
-            Symbol(MayBeNull<term!(symbol)>),
-            Error(MayBeNull<term!(Error)>),
-            ArrayBuffer(MayBeNull<term!(ArrayBuffer)>),
-            DataView(MayBeNull<term!(DataView)>),
-            Int8Array(MayBeNull<term!(Int8Array)>),
-            Int16Array(MayBeNull<term!(Int16Array)>),
-            Int32Array(MayBeNull<term!(Int32Array)>),
-            Uint8Array(MayBeNull<term!(Uint8Array)>),
-            Uint16Array(MayBeNull<term!(Uint16Array)>),
-            Uint32Array(MayBeNull<term!(Uint32Array)>),
-            Uint8ClampedArray(MayBeNull<term!(Uint8ClampedArray)>),
-            Float32Array(MayBeNull<term!(Float32Array)>),
-            Float64Array(MayBeNull<term!(Float64Array)>),
-            FrozenArrayType(MayBeNull<FrozenArrayType<'a>>),
-            RecordType(MayBeNull<RecordType<'a>>),
-            Identifier(MayBeNull<Identifier<'a>>),
+            NonAny(NonAnyType<'a>),
         }),
         Union(MayBeNull<UnionType<'a>>),
+    }
+
+    // Parses any single non-any type
+    enum NonAnyType<'a> {
+        Promise(PromiseType<'a>),
+        Integer(MayBeNull<IntegerType>),
+        FloatingPoint(MayBeNull<FloatingPointType>),
+        Boolean(MayBeNull<term!(boolean)>),
+        Byte(MayBeNull<term!(byte)>),
+        Octet(MayBeNull<term!(octet)>),
+        ByteString(MayBeNull<term!(ByteString)>),
+        DOMString(MayBeNull<term!(DOMString)>),
+        USVString(MayBeNull<term!(USVString)>),
+        Sequence(MayBeNull<SequenceType<'a>>),
+        Object(MayBeNull<term!(object)>),
+        Symbol(MayBeNull<term!(symbol)>),
+        Error(MayBeNull<term!(Error)>),
+        ArrayBuffer(MayBeNull<term!(ArrayBuffer)>),
+        DataView(MayBeNull<term!(DataView)>),
+        Int8Array(MayBeNull<term!(Int8Array)>),
+        Int16Array(MayBeNull<term!(Int16Array)>),
+        Int32Array(MayBeNull<term!(Int32Array)>),
+        Uint8Array(MayBeNull<term!(Uint8Array)>),
+        Uint16Array(MayBeNull<term!(Uint16Array)>),
+        Uint32Array(MayBeNull<term!(Uint32Array)>),
+        Uint8ClampedArray(MayBeNull<term!(Uint8ClampedArray)>),
+        Float32Array(MayBeNull<term!(Float32Array)>),
+        Float64Array(MayBeNull<term!(Float64Array)>),
+        FrozenArrayType(MayBeNull<FrozenArrayType<'a>>),
+        RecordType(MayBeNull<RecordType<'a>>),
+        Identifier(MayBeNull<Identifier<'a>>),
     }
 
     /// Parses `sequence<Type>`
@@ -126,36 +131,7 @@ ast_types! {
 
     /// Parses one of the member of a union type
     enum UnionMemberType<'a> {
-        /// Parses one of the types
-        Single(enum UnionSingleType<'a> {
-            Promise(PromiseType<'a>),
-            Integer(MayBeNull<IntegerType>),
-            FloatingPoint(MayBeNull<FloatingPointType>),
-            Boolean(MayBeNull<term!(boolean)>),
-            Byte(MayBeNull<term!(byte)>),
-            Octet(MayBeNull<term!(octet)>),
-            ByteString(MayBeNull<term!(ByteString)>),
-            DOMString(MayBeNull<term!(DOMString)>),
-            USVString(MayBeNull<term!(USVString)>),
-            Sequence(MayBeNull<SequenceType<'a>>),
-            Object(MayBeNull<term!(object)>),
-            Symbol(MayBeNull<term!(symbol)>),
-            Error(MayBeNull<term!(Error)>),
-            ArrayBuffer(MayBeNull<term!(ArrayBuffer)>),
-            DataView(MayBeNull<term!(DataView)>),
-            Int8Array(MayBeNull<term!(Int8Array)>),
-            Int16Array(MayBeNull<term!(Int16Array)>),
-            Int32Array(MayBeNull<term!(Int32Array)>),
-            Uint8Array(MayBeNull<term!(Uint8Array)>),
-            Uint16Array(MayBeNull<term!(Uint16Array)>),
-            Uint32Array(MayBeNull<term!(Uint32Array)>),
-            Uint8ClampedArray(MayBeNull<term!(Uint8ClampedArray)>),
-            Float32Array(MayBeNull<term!(Float32Array)>),
-            Float64Array(MayBeNull<term!(Float64Array)>),
-            FrozenArrayType(MayBeNull<FrozenArrayType<'a>>),
-            RecordType(MayBeNull<RecordType<'a>>),
-            Identifier(MayBeNull<Identifier<'a>>),
-        }),
+        Single(NonAnyType<'a>),
         Union(MayBeNull<UnionType<'a>>),
     }
 
@@ -217,7 +193,7 @@ mod test {
     );
 
     test_variants!(
-        UnionSingleType {
+        NonAnyType {
             Promise == "Promise<long>",
             Integer == "long",
             FloatingPoint == "float",
@@ -326,33 +302,7 @@ mod test {
     test_variants!(
         SingleType {
             Any == "any",
-            Promise == "Promise<short>",
-            Integer == "long",
-            FloatingPoint == "float",
-            Boolean == "boolean",
-            Byte == "byte",
-            Octet == "octet",
-            ByteString == "ByteString",
-            DOMString == "DOMString",
-            USVString == "USVString",
-            Sequence == "sequence<short>",
-            Object == "object",
-            Symbol == "symbol",
-            Error == "Error",
-            ArrayBuffer == "ArrayBuffer",
-            DataView == "DataView",
-            Int8Array == "Int8Array",
-            Int16Array == "Int16Array",
-            Int32Array == "Int32Array",
-            Uint8Array == "Uint8Array",
-            Uint16Array == "Uint16Array",
-            Uint32Array == "Uint32Array",
-            Uint8ClampedArray == "Uint8ClampedArray",
-            Float32Array == "Float32Array",
-            Float64Array == "Float64Array",
-            FrozenArrayType == "FrozenArray<short>",
-            RecordType == "record<DOMString, short>",
-            Identifier == "someName"
+            NonAny == "Promise<short>",
         }
     );
 

--- a/tests/webidl.rs
+++ b/tests/webidl.rs
@@ -15,7 +15,7 @@ pub fn should_parse_dom_webidl() {
     let content = read_file("./tests/defs/dom.webidl");
     let parsed = weedle::parse(&content).unwrap();
 
-    assert_eq!(parsed.definitions.len(), 62);
+    assert_eq!(parsed.len(), 62);
 }
 
 #[test]
@@ -23,5 +23,5 @@ fn should_parse_html_webidl() {
     let content = read_file("./tests/defs/html.webidl");
     let parsed = weedle::parse(&content).unwrap();
 
-    assert_eq!(parsed.definitions.len(), 325);
+    assert_eq!(parsed.len(), 325);
 }


### PR DESCRIPTION
We are interested in using this crate for wasm-bindgen. In investigating some issues that we are having, I decided to do a bit of refactoring. Note, this is a breaking change to the API (see below), but it looks like there are currently no public downstream crates, I don't believe this is a real issue.

Breaking changes:
- The AST now borrows from the input string, it is no longer owned.
- `*I64` has been renamed to `*Lit` since these literals could contain non-valid i64 strings (e.g. 2^63).
- A new inner type `FloatValueLit` was added for `FloatLit::Value`. This was to be a more consistent with other enums which didn't do any non-trivial parsing.
- `Identifier` and `ExtendedAttributeNoArgs` are now tuple types. Again, this was done to be more consistent with other newtypes, namely literals.
- `UnionSingleType` was renamed to `NonAnyType` and is now also used in `SingleType`.

The main other notable change is that I switched to using regex finds rather than captures. The captures weren't really needed, and they were causing the debug builds to be really slow.