### PR TITLE
Support attributed types in unions

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -133,7 +133,7 @@ ast_types! {
 
     /// Parses one of the member of a union type
     enum UnionMemberType<'a> {
-        Single(NonAnyType<'a>),
+        Single(AttributedNonAnyType<'a>),
         Union(MayBeNull<UnionType<'a>>),
     }
 
@@ -157,6 +157,12 @@ ast_types! {
     struct AttributedType<'a> {
         attributes: Option<ExtendedAttributeList<'a>>,
         type_: Type<'a>,
+    }
+
+    /// Parses `[attributes]? type` where the type is a single non-any type
+    struct AttributedNonAnyType<'a> {
+        attributes: Option<ExtendedAttributeList<'a>>,
+        type_: NonAnyType<'a>,
     }
 }
 
@@ -231,7 +237,7 @@ mod test {
     test_variants!(
         UnionMemberType {
             Single == "byte",
-            Union == "(byte or byte)"
+            Union == "([Clamp] unsigned long or byte)"
         }
     );
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -334,4 +334,49 @@ mod test {
         "";
         ::types::Type;
     });
+
+    #[test]
+    fn should_parse_union_member_type_attributed_union() {
+        use crate::types::UnionMemberType;
+        let (rem, parsed) =
+            UnionMemberType::parse(nom::types::CompleteStr("([Clamp] byte or [Named] byte)"))
+                .unwrap();
+        assert_eq!(rem, nom::types::CompleteStr(""));
+        match parsed {
+            UnionMemberType::Union(MayBeNull {
+                type_:
+                    Braced {
+                        body: Punctuated { list, .. },
+                        ..
+                    },
+                ..
+            }) => {
+                assert_eq!(list.len(), 2);
+
+                match list[0] {
+                    UnionMemberType::Single(AttributedNonAnyType { ref attributes, .. }) => {
+                        assert!(attributes.is_some());
+                    }
+
+                    _ => {
+                        panic!("Failed to parse list[0] attributes");
+                    }
+                };
+
+                match list[1] {
+                    UnionMemberType::Single(AttributedNonAnyType { ref attributes, .. }) => {
+                        assert!(attributes.is_some());
+                    }
+
+                    _ => {
+                        panic!("Failed to parse list[1] attributes");
+                    }
+                };
+            }
+
+            _ => {
+                panic!("Failed to parse");
+            }
+        }
+    }
 }

--- a/tests/defs/mediacapture-streams.webidl
+++ b/tests/defs/mediacapture-streams.webidl
@@ -1,0 +1,246 @@
+[Exposed=Window,
+ Constructor,
+ Constructor(MediaStream stream),
+ Constructor(sequence<MediaStreamTrack> tracks)]
+interface MediaStream : EventTarget {
+    readonly        attribute DOMString id;
+    sequence<MediaStreamTrack> getAudioTracks();
+    sequence<MediaStreamTrack> getVideoTracks();
+    sequence<MediaStreamTrack> getTracks();
+    MediaStreamTrack? getTrackById(DOMString trackId);
+    void addTrack(MediaStreamTrack track);
+    void removeTrack(MediaStreamTrack track);
+    MediaStream clone();
+    readonly        attribute boolean active;
+                    attribute EventHandler onaddtrack;
+                    attribute EventHandler onremovetrack;
+};
+
+[Exposed=Window]
+interface MediaStreamTrack : EventTarget {
+    readonly        attribute DOMString kind;
+    readonly        attribute DOMString id;
+    readonly        attribute DOMString label;
+                    attribute boolean enabled;
+    readonly        attribute boolean muted;
+                    attribute EventHandler onmute;
+                    attribute EventHandler onunmute;
+    readonly        attribute MediaStreamTrackState readyState;
+                    attribute EventHandler onended;
+    MediaStreamTrack clone();
+    void stop();
+    MediaTrackCapabilities getCapabilities();
+    MediaTrackConstraints getConstraints();
+    MediaTrackSettings getSettings();
+    Promise<void> applyConstraints(optional MediaTrackConstraints constraints);
+};
+
+enum MediaStreamTrackState {
+    "live",
+    "ended"
+};
+
+dictionary MediaTrackSupportedConstraints {
+             boolean width = true;
+             boolean height = true;
+             boolean aspectRatio = true;
+             boolean frameRate = true;
+             boolean facingMode = true;
+             boolean resizeMode = true;
+             boolean volume = true;
+             boolean sampleRate = true;
+             boolean sampleSize = true;
+             boolean echoCancellation = true;
+             boolean autoGainControl = true;
+             boolean noiseSuppression = true;
+             boolean latency = true;
+             boolean channelCount = true;
+             boolean deviceId = true;
+             boolean groupId = true;
+};
+
+dictionary MediaTrackCapabilities {
+             ULongRange width;
+             ULongRange height;
+             DoubleRange aspectRatio;
+             DoubleRange frameRate;
+             sequence<DOMString> facingMode;
+             sequence<DOMString> resizeMode;
+             DoubleRange volume;
+             ULongRange sampleRate;
+             ULongRange sampleSize;
+             sequence<boolean> echoCancellation;
+             sequence<boolean> autoGainControl;
+             sequence<boolean> noiseSuppression;
+             DoubleRange latency;
+             ULongRange channelCount;
+             DOMString deviceId;
+             DOMString groupId;
+};
+
+dictionary MediaTrackConstraints : MediaTrackConstraintSet {
+             sequence<MediaTrackConstraintSet> advanced;
+};
+
+dictionary MediaTrackConstraintSet {
+             ConstrainULong width;
+             ConstrainULong height;
+             ConstrainDouble aspectRatio;
+             ConstrainDouble frameRate;
+             ConstrainDOMString facingMode;
+             ConstrainDOMString resizeMode;
+             ConstrainDouble volume;
+             ConstrainULong sampleRate;
+             ConstrainULong sampleSize;
+             ConstrainBoolean echoCancellation;
+             ConstrainBoolean autoGainControl;
+             ConstrainBoolean noiseSuppression;
+             ConstrainDouble latency;
+             ConstrainULong channelCount;
+             ConstrainDOMString deviceId;
+             ConstrainDOMString groupId;
+};
+
+dictionary MediaTrackSettings {
+             long width;
+             long height;
+             double aspectRatio;
+             double frameRate;
+             DOMString facingMode;
+             DOMString resizeMode;
+             double volume;
+             long sampleRate;
+             long sampleSize;
+             boolean echoCancellation;
+             boolean autoGainControl;
+             boolean noiseSuppression;
+             double latency;
+             long channelCount;
+             DOMString deviceId;
+             DOMString groupId;
+};
+
+enum VideoFacingModeEnum {
+    "user",
+    "environment",
+    "left",
+    "right"
+};
+
+enum VideoResizeModeEnum {
+    "none",
+    "crop-and-scale"
+};
+
+[Exposed=Window,
+ Constructor(DOMString type, MediaStreamTrackEventInit eventInitDict)]
+interface MediaStreamTrackEvent : Event {
+    [SameObject]
+    readonly        attribute MediaStreamTrack track;
+};
+
+dictionary MediaStreamTrackEventInit : EventInit {
+    required MediaStreamTrack track;
+};
+
+partial interface Navigator {
+    [SameObject, SecureContext]
+    readonly        attribute MediaDevices mediaDevices;
+};
+
+[Exposed=Window, SecureContext]
+interface MediaDevices : EventTarget {
+                    attribute EventHandler ondevicechange;
+    Promise<sequence<MediaDeviceInfo>> enumerateDevices();
+};
+
+[Exposed=Window, SecureContext]
+interface MediaDeviceInfo {
+    readonly        attribute DOMString deviceId;
+    readonly        attribute MediaDeviceKind kind;
+    readonly        attribute DOMString label;
+    readonly        attribute DOMString groupId;
+    [Default] object toJSON();
+};
+
+enum MediaDeviceKind {
+    "audioinput",
+    "audiooutput",
+    "videoinput"
+};
+
+[Exposed=Window] interface InputDeviceInfo : MediaDeviceInfo {
+    MediaTrackCapabilities getCapabilities();
+};
+
+partial interface Navigator {
+    [SecureContext]
+    void getUserMedia(MediaStreamConstraints constraints, NavigatorUserMediaSuccessCallback successCallback, NavigatorUserMediaErrorCallback errorCallback);
+};
+
+partial interface MediaDevices {
+    MediaTrackSupportedConstraints getSupportedConstraints();
+    Promise<MediaStream> getUserMedia(optional MediaStreamConstraints constraints);
+};
+
+dictionary MediaStreamConstraints {
+             (boolean or MediaTrackConstraints) video = false;
+             (boolean or MediaTrackConstraints) audio = false;
+};
+
+callback NavigatorUserMediaSuccessCallback = void (MediaStream stream);
+
+callback NavigatorUserMediaErrorCallback = void (MediaStreamError error);
+
+typedef object MediaStreamError;
+
+dictionary DoubleRange {
+             double max;
+             double min;
+};
+
+dictionary ConstrainDoubleRange : DoubleRange {
+             double exact;
+             double ideal;
+};
+
+dictionary ULongRange {
+             [Clamp] unsigned long max;
+             [Clamp] unsigned long min;
+};
+
+dictionary ConstrainULongRange : ULongRange {
+             [Clamp] unsigned long exact;
+             [Clamp] unsigned long ideal;
+};
+
+dictionary ConstrainBooleanParameters {
+             boolean exact;
+             boolean ideal;
+};
+
+dictionary ConstrainDOMStringParameters {
+             (DOMString or sequence<DOMString>) exact;
+             (DOMString or sequence<DOMString>) ideal;
+};
+
+typedef ([Clamp] unsigned long or ConstrainULongRange) ConstrainULong;
+
+typedef (double or ConstrainDoubleRange) ConstrainDouble;
+
+typedef (boolean or ConstrainBooleanParameters) ConstrainBoolean;
+
+typedef (DOMString or sequence<DOMString> or ConstrainDOMStringParameters) ConstrainDOMString;
+
+dictionary Capabilities {
+};
+
+dictionary Settings {
+};
+
+dictionary ConstraintSet {
+};
+
+dictionary Constraints : ConstraintSet {
+             sequence<ConstraintSet> advanced;
+};

--- a/tests/webidl.rs
+++ b/tests/webidl.rs
@@ -25,3 +25,11 @@ fn should_parse_html_webidl() {
 
     assert_eq!(parsed.len(), 325);
 }
+
+#[test]
+fn should_parse_mediacapture_streams_webidl() {
+    let content = read_file("./tests/defs/mediacapture-streams.webidl");
+    let parsed = weedle::parse(&content).unwrap();
+
+    assert_eq!(parsed.len(), 37);
+}


### PR DESCRIPTION
Work towards fixing #19.

According to https://heycam.github.io/webidl/#prod-UnionMemberType it seems the `UnionMemberType::Single` variant should accept an attributed non-any type, whereas the issue mentions adding them to `MaybeNull` ?

I marked the PR as WIP because of the questions I asked on Discord, especially about how to test this in an acceptable fashion, as I'm not sure how to do so with the macros. Also, as I'm not very familiar with weedle/webidl, I wanted to check whether this PR was on the right track ?

I modified the `UnionMemberType` `test_variants!` but I'm not sure how to add better coverage of single/union attributed/non-attributed types with the macros. I don't think the individual types inside the `UnionMemberType` are verified in these tests so couldn't easily add assertions about attribute parsing there. I therefore also added an example manual unit test — however, since it's not using the macros, it's very verbose/ugly compared to the other tests. It's in the last commit, and is the one I'll need a bit of guidance on how to clean up.

I also added the webidl file from which I think the weird `typedef ([Clamp] unsigned long or ConstrainULongRange) ConstrainULong;` fragment is extracted.

