### PR TITLE
Port to nom 5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ readme = "./README.md"
 edition = "2018"
 
 [dependencies]
-nom = "4.0.0"
+nom = "^5.0.1"

--- a/src/common.rs
+++ b/src/common.rs
@@ -87,7 +87,7 @@ ast_types! {
                 take_while!(|c: char| c.is_ascii_alphanumeric() || c == '_' || c == '-') >>
                 (())
             )) >>
-            (id.0)
+            (id)
         )),
     )
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ use interface::{Inheritance, InterfaceMembers};
 use literal::StringLit;
 use mixin::MixinMembers;
 use namespace::NamespaceMembers;
-pub use nom::{types::CompleteStr, Err, Context, IResult};
+pub use nom::{Err, IResult};
 use types::{AttributedType, ReturnType};
 
 #[macro_use]
@@ -69,30 +69,30 @@ pub mod types;
 ///
 /// println!("{:?}", parsed);
 /// ```
-pub fn parse<'a>(raw: &'a str) -> Result<Definitions<'a>, Err<CompleteStr<'a>, u32>> {
-    let (remaining, parsed) = Definitions::parse(CompleteStr(raw))?;
+pub fn parse<'a>(raw: &'a str) -> Result<Definitions<'a>, Err<&str>> {
+    let (remaining, parsed) = Definitions::parse(raw).unwrap();
     if remaining.len() > 0 {
-        Result::Err(Err::Failure(nom::Context::Code(remaining, nom::ErrorKind::Custom(0))))
+        Result::Err(Err::Failure(remaining))
     } else {
         Ok(parsed)
     }
 }
 
 pub trait Parse<'a>: Sized {
-    fn parse(input: CompleteStr<'a>) -> IResult<CompleteStr<'a>, Self>;
+    fn parse(input: &'a str) -> IResult<&'a str, Self>;
 }
 
 /// Parses WebIDL definitions. It is the root struct for a complete WebIDL definition.
 ///
 /// ### Example
 /// ```
-/// use weedle::{Definitions, CompleteStr, Parse};
+/// use weedle::{Definitions, Parse};
 ///
-/// let (_, parsed) = Definitions::parse(CompleteStr("
+/// let (_, parsed) = Definitions::parse("
 ///     interface Window {
 ///         readonly attribute Storage sessionStorage;
 ///     };
-/// ")).unwrap();
+/// ").unwrap();
 ///
 /// println!("{:?}", parsed);
 /// ```

--- a/src/literal.rs
+++ b/src/literal.rs
@@ -12,7 +12,7 @@ ast_types! {
                     take_while!(|c: char| c.is_ascii_digit()) >>
                     (())
                 ))),
-                |inner| inner.0
+                |inner| inner
             ),
         )),
         /// Parses `-?0[Xx][0-9A-Fa-f]+)`
@@ -26,7 +26,7 @@ ast_types! {
                     take_while!(|c: char| c.is_ascii_hexdigit()) >>
                     (())
                 ))),
-                |inner| inner.0
+                |inner| inner
             ),
         )),
         /// Parses `-?0[0-7]*`
@@ -39,7 +39,7 @@ ast_types! {
                     take_while!(|c| '0' <= c && c <= '7') >>
                     (())
                 ))),
-                |inner| inner.0
+                |inner| inner
             ),
         )),
     }
@@ -53,7 +53,7 @@ ast_types! {
             char!('"') >>
             s: take_while!(|c| c != '"') >>
             char!('"') >>
-            (s.0)
+            (s)
         )),
     )
 
@@ -145,7 +145,7 @@ ast_types! {
                     ) >>
                     (())
                 ))),
-                |inner| inner.0
+                |inner| inner
             ),
         )),
         NegInfinity(term!(-Infinity)),

--- a/src/term.rs
+++ b/src/term.rs
@@ -21,11 +21,11 @@ macro_rules! ident_tag (
             match tag!($i, $tok) {
                 Err(e) => Err(e),
                 Ok((i, o)) => {
-                    let mut res = Ok((i, o));
+                    use nom::{character::is_alphanumeric, error::ErrorKind};
+                    let mut res: Result<(&str, &str), nom::Err<_>> = Ok((i, o));
                     if let Some(&c) = i.as_bytes().first() {
-                        use $crate::nom::{Context, Err, ErrorKind, is_alphanumeric};
                         if is_alphanumeric(c) || c == b'_' || c == b'-' {
-                            res = Err(Err::Error(Context::Code($i, ErrorKind::Tag::<u32>)));
+                            res = Err(nom::Err::Error(($i, ErrorKind::Tag)));
                         }
                     }
                     res
@@ -560,40 +560,39 @@ mod test {
                 mod $m {
                     use super::super::$typ;
                     use crate::Parse;
-                    use nom::types::CompleteStr;
 
                     #[test]
                     fn should_parse() {
-                        let (rem, parsed) = $typ::parse(CompleteStr(concat!($string))).unwrap();
-                        assert_eq!(rem, CompleteStr(""));
+                        let (rem, parsed) = $typ::parse(concat!($string)).unwrap();
+                        assert_eq!(rem, "");
                         assert_eq!(parsed, $typ);
                     }
 
                     #[test]
                     fn should_parse_with_preceding_spaces() {
-                        let (rem, parsed) = $typ::parse(CompleteStr(concat!("  ", $string))).unwrap();
-                        assert_eq!(rem, CompleteStr(""));
+                        let (rem, parsed) = $typ::parse(concat!("  ", $string)).unwrap();
+                        assert_eq!(rem, "");
                         assert_eq!(parsed, $typ);
                     }
 
                     #[test]
                     fn should_parse_with_succeeding_spaces() {
-                        let (rem, parsed) = $typ::parse(CompleteStr(concat!($string, "  "))).unwrap();
-                        assert_eq!(rem, CompleteStr(""));
+                        let (rem, parsed) = $typ::parse(concat!($string, "  ")).unwrap();
+                        assert_eq!(rem, "");
                         assert_eq!(parsed, $typ);
                     }
 
                     #[test]
                     fn should_parse_with_surrounding_spaces() {
-                        let (rem, parsed) = $typ::parse(CompleteStr(concat!("  ", $string, "  "))).unwrap();
-                        assert_eq!(rem, CompleteStr(""));
+                        let (rem, parsed) = $typ::parse(concat!("  ", $string, "  ")).unwrap();
+                        assert_eq!(rem, "");
                         assert_eq!(parsed, $typ);
                     }
 
                     #[test]
                     fn should_parse_if_anything_next() {
-                        let (rem, parsed) = $typ::parse(CompleteStr(concat!($string, "  anything"))).unwrap();
-                        assert_eq!(rem, CompleteStr("anything"));
+                        let (rem, parsed) = $typ::parse(concat!($string, "  anything")).unwrap();
+                        assert_eq!(rem, "anything");
                         assert_eq!(parsed, $typ);
                     }
                 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -339,9 +339,9 @@ mod test {
     fn should_parse_union_member_type_attributed_union() {
         use crate::types::UnionMemberType;
         let (rem, parsed) =
-            UnionMemberType::parse(nom::types::CompleteStr("([Clamp] byte or [Named] byte)"))
+            UnionMemberType::parse("([Clamp] byte or [Named] byte)")
                 .unwrap();
-        assert_eq!(rem, nom::types::CompleteStr(""));
+        assert_eq!(rem, "");
         match parsed {
             UnionMemberType::Union(MayBeNull {
                 type_:

--- a/src/whitespace.rs
+++ b/src/whitespace.rs
@@ -1,6 +1,6 @@
-use crate::{CompleteStr, IResult};
+use crate::{IResult};
 
-pub fn sp(input: CompleteStr) -> IResult<CompleteStr, CompleteStr> {
+pub fn sp(input: &str) -> IResult<&str, &str> {
     recognize!(
         input,
         many0!(


### PR DESCRIPTION
This PR fixes the compile errors after bumping the nom version but many of the tests still fail. Probably has to do with what is mentioned [here](https://github.com/Geal/nom/blob/master/doc/upgrading_to_nom_5.md#removal-of-completestr-and-completebyteslice) regarding the removal of `CompleteStr`.

I probably won't be able to finish this PR for awhile but at least this gets y'all part of the way toward nom 5.