### PR TITLE
Support async iterable declarations

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -75,6 +75,25 @@ ast_types! {
                 semi_colon: term!(;),
             }),
         }),
+        /// Parses an async iterable declaration `[attributes]? async (iterable<attributedtype> | iterable<attributedtype, attributedtype>) (( args ))? ;`
+        AsyncIterable(enum AsyncIterableInterfaceMember<'a> {
+            /// Parses an async iterable declaration `[attributes]? async iterable<attributedtype> (( args ))? ;`
+            Single(struct SingleTypedAsyncIterable<'a> {
+                attributes: Option<ExtendedAttributeList<'a>>,
+                iterable: term!(async iterable),
+                generics: Generics<AttributedType<'a>>,
+                args: Option<Parenthesized<ArgumentList<'a>>>,
+                semi_colon: term!(;),
+            }),
+            /// Parses an async iterable declaration `[attributes]? async iterable<attributedtype, attributedtype> (( args ))? ;`
+            Double(struct DoubleTypedAsyncIterable<'a> {
+                attributes: Option<ExtendedAttributeList<'a>>,
+                iterable: term!(async iterable),
+                generics: Generics<(AttributedType<'a>, term!(,), AttributedType<'a>)>,
+                args: Option<Parenthesized<ArgumentList<'a>>>,
+                semi_colon: term!(;),
+            }),
+        }),
         /// Parses an maplike declaration `[attributes]? readonly? maplike<attributedtype, attributedtype>;`
         Maplike(struct MaplikeInterfaceMember<'a> {
             attributes: Option<ExtendedAttributeList<'a>>,
@@ -176,6 +195,34 @@ mod test {
         "";
         SingleTypedIterable;
         attributes.is_none();
+    });
+
+    test!(should_parse_double_typed_async_iterable { "async iterable<long, long>;" =>
+        "";
+        DoubleTypedAsyncIterable;
+        attributes.is_none();
+        args.is_none();
+    });
+
+    test!(should_parse_double_typed_async_iterable_with_args { "async iterable<long, long>(long a);" =>
+        "";
+        DoubleTypedAsyncIterable;
+        attributes.is_none();
+        args.is_some();
+    });
+
+    test!(should_parse_single_typed_async_iterable { "async iterable<long>;" =>
+        "";
+        SingleTypedAsyncIterable;
+        attributes.is_none();
+        args.is_none();
+    });
+
+    test!(should_parse_single_typed_async_iterable_with_args { "async iterable<long>(long a);" =>
+        "";
+        SingleTypedAsyncIterable;
+        attributes.is_none();
+        args.is_some();
     });
 
     test!(should_parse_constructor_interface_member { "constructor(long a);" =>

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -80,8 +80,7 @@ ast_types! {
             /// Parses an async iterable declaration `[attributes]? async iterable<attributedtype> (( args ))? ;`
             Single(struct SingleTypedAsyncIterable<'a> {
                 attributes: Option<ExtendedAttributeList<'a>>,
-                r#async: term!(async),
-                iterable: term!(iterable),
+                async_iterable: (term!(async), term!(iterable)),
                 generics: Generics<AttributedType<'a>>,
                 args: Option<Parenthesized<ArgumentList<'a>>>,
                 semi_colon: term!(;),
@@ -89,8 +88,7 @@ ast_types! {
             /// Parses an async iterable declaration `[attributes]? async iterable<attributedtype, attributedtype> (( args ))? ;`
             Double(struct DoubleTypedAsyncIterable<'a> {
                 attributes: Option<ExtendedAttributeList<'a>>,
-                r#async: term!(async),
-                iterable: term!(iterable),
+                async_iterable: (term!(async), term!(iterable)),
                 generics: Generics<(AttributedType<'a>, term!(,), AttributedType<'a>)>,
                 args: Option<Parenthesized<ArgumentList<'a>>>,
                 semi_colon: term!(;),

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -80,7 +80,8 @@ ast_types! {
             /// Parses an async iterable declaration `[attributes]? async iterable<attributedtype> (( args ))? ;`
             Single(struct SingleTypedAsyncIterable<'a> {
                 attributes: Option<ExtendedAttributeList<'a>>,
-                iterable: term!(async iterable),
+                r#async: term!(async),
+                iterable: term!(iterable),
                 generics: Generics<AttributedType<'a>>,
                 args: Option<Parenthesized<ArgumentList<'a>>>,
                 semi_colon: term!(;),
@@ -88,7 +89,8 @@ ast_types! {
             /// Parses an async iterable declaration `[attributes]? async iterable<attributedtype, attributedtype> (( args ))? ;`
             Double(struct DoubleTypedAsyncIterable<'a> {
                 attributes: Option<ExtendedAttributeList<'a>>,
-                iterable: term!(async iterable),
+                r#async: term!(async),
+                iterable: term!(iterable),
                 generics: Generics<(AttributedType<'a>, term!(,), AttributedType<'a>)>,
                 args: Option<Parenthesized<ArgumentList<'a>>>,
                 semi_colon: term!(;),

--- a/src/term.rs
+++ b/src/term.rs
@@ -109,6 +109,9 @@ generate_terms_for_names! {
     /// Represents the terminal symbol `optional`
     Optional => "optional",
 
+    /// Represents the terminal symbol `async`
+    Async => "async",
+
     /// Represents the terminal symbol `attribute`
     Attribute => "attribute",
 
@@ -141,9 +144,6 @@ generate_terms_for_names! {
 
     /// Represents the terminal symbol `iterable`
     Iterable => "iterable",
-
-    /// Represents the terminal symbol `async`
-    Async => "async",
 
     /// Represents the terminal symbol `maplike`
     Maplike => "maplike",
@@ -364,6 +364,9 @@ macro_rules! term {
     (optional) => {
         $crate::term::Optional
     };
+    (async) => {
+        $crate::term::Async
+    };
     (attribute) => {
         $crate::term::Attribute
     };
@@ -396,9 +399,6 @@ macro_rules! term {
     };
     (iterable) => {
         $crate::term::Iterable
-    };
-    (async) => {
-        $crate::term::Async
     };
     (maplike) => {
         $crate::term::Maplike
@@ -631,6 +631,7 @@ mod test {
         qmark, QMark, "?";
         or, Or, "or";
         optional, Optional, "optional";
+        r#async, Async, "async";
         attribute, Attribute, "attribute";
         callback, Callback, "callback";
         const_, Const, "const";
@@ -642,7 +643,6 @@ mod test {
         inherit, Inherit, "inherit";
         interface, Interface, "interface";
         iterable, Iterable, "iterable";
-        r#async, Async, "async";
         maplike, Maplike, "maplike";
         namespace, Namespace, "namespace";
         partial, Partial, "partial";

--- a/src/term.rs
+++ b/src/term.rs
@@ -142,6 +142,9 @@ generate_terms_for_names! {
     /// Represents the terminal symbol `iterable`
     Iterable => "iterable",
 
+    /// Represents the terminal symbol `async iterable`
+    AsyncIterable => "async iterable",
+
     /// Represents the terminal symbol `maplike`
     Maplike => "maplike",
 
@@ -394,6 +397,9 @@ macro_rules! term {
     (iterable) => {
         $crate::term::Iterable
     };
+    (async iterable) => {
+        $crate::term::AsyncIterable
+    };
     (maplike) => {
         $crate::term::Maplike
     };
@@ -636,6 +642,7 @@ mod test {
         inherit, Inherit, "inherit";
         interface, Interface, "interface";
         iterable, Iterable, "iterable";
+        asynciterable, AsyncIterable, "async iterable";
         maplike, Maplike, "maplike";
         namespace, Namespace, "namespace";
         partial, Partial, "partial";

--- a/src/term.rs
+++ b/src/term.rs
@@ -631,7 +631,7 @@ mod test {
         qmark, QMark, "?";
         or, Or, "or";
         optional, Optional, "optional";
-        r#async, Async, "async";
+        async_, Async, "async";
         attribute, Attribute, "attribute";
         callback, Callback, "callback";
         const_, Const, "const";

--- a/src/term.rs
+++ b/src/term.rs
@@ -142,8 +142,8 @@ generate_terms_for_names! {
     /// Represents the terminal symbol `iterable`
     Iterable => "iterable",
 
-    /// Represents the terminal symbol `async iterable`
-    AsyncIterable => "async iterable",
+    /// Represents the terminal symbol `async`
+    Async => "async",
 
     /// Represents the terminal symbol `maplike`
     Maplike => "maplike",
@@ -397,8 +397,8 @@ macro_rules! term {
     (iterable) => {
         $crate::term::Iterable
     };
-    (async iterable) => {
-        $crate::term::AsyncIterable
+    (async) => {
+        $crate::term::Async
     };
     (maplike) => {
         $crate::term::Maplike
@@ -642,7 +642,7 @@ mod test {
         inherit, Inherit, "inherit";
         interface, Interface, "interface";
         iterable, Iterable, "iterable";
-        asynciterable, AsyncIterable, "async iterable";
+        r#async, Async, "async";
         maplike, Maplike, "maplike";
         namespace, Namespace, "namespace";
         partial, Partial, "partial";

--- a/tests/defs/streams.webidl
+++ b/tests/defs/streams.webidl
@@ -1,0 +1,204 @@
+[Exposed=(Window,Worker,Worklet)]
+interface ReadableStream {
+  constructor(optional object underlyingSource, optional QueuingStrategy strategy = {});
+
+  readonly attribute boolean locked;
+
+  Promise<void> cancel(optional any reason);
+  ReadableStreamReader getReader(optional ReadableStreamGetReaderOptions options = {});
+  ReadableStream pipeThrough(ReadableWritablePair transform, optional StreamPipeOptions options = {});
+  Promise<void> pipeTo(WritableStream destination, optional StreamPipeOptions options = {});
+  sequence<ReadableStream> tee();
+
+  async iterable<any>(optional ReadableStreamIteratorOptions options = {});
+};
+
+typedef (ReadableStreamDefaultReader or ReadableStreamBYOBReader) ReadableStreamReader;
+
+enum ReadableStreamReaderMode { "byob" };
+
+dictionary ReadableStreamGetReaderOptions {
+  ReadableStreamReaderMode mode;
+};
+
+dictionary ReadableStreamIteratorOptions {
+  boolean preventCancel = false;
+};
+
+dictionary ReadableWritablePair {
+  required ReadableStream readable;
+  required WritableStream writable;
+};
+
+dictionary StreamPipeOptions {
+  boolean preventClose = false;
+  boolean preventAbort = false;
+  boolean preventCancel = false;
+  AbortSignal signal;
+};
+
+dictionary UnderlyingSource {
+  UnderlyingSourceStartCallback start;
+  UnderlyingSourcePullCallback pull;
+  UnderlyingSourceCancelCallback cancel;
+  ReadableStreamType type;
+  [EnforceRange] unsigned long long autoAllocateChunkSize;
+};
+
+typedef (ReadableStreamDefaultController or ReadableByteStreamController) ReadableStreamController;
+
+callback UnderlyingSourceStartCallback = any (ReadableStreamController controller);
+callback UnderlyingSourcePullCallback = Promise<void> (ReadableStreamController controller);
+callback UnderlyingSourceCancelCallback = Promise<void> (optional any reason);
+
+enum ReadableStreamType { "bytes" };
+
+[Exposed=(Window,Worker,Worklet)]
+interface ReadableStreamDefaultReader {
+  constructor(ReadableStream stream);
+
+  readonly attribute Promise<void> closed;
+
+  Promise<void> cancel(optional any reason);
+  Promise<any> read();
+  void releaseLock();
+};
+
+[Exposed=(Window,Worker,Worklet)]
+interface ReadableStreamBYOBReader {
+  constructor(ReadableStream stream);
+
+  readonly attribute Promise<void> closed;
+
+  Promise<void> cancel(optional any reason);
+  Promise<any> read(ArrayBufferView view);
+  void releaseLock();
+};
+
+[Exposed=(Window,Worker,Worklet)]
+interface ReadableStreamDefaultController {
+  readonly attribute unrestricted double? desiredSize;
+
+  void close();
+  void enqueue(optional any chunk);
+  void error(optional any e);
+};
+
+[Exposed=(Window,Worker,Worklet)]
+interface ReadableByteStreamController {
+  readonly attribute ReadableStreamBYOBRequest? byobRequest;
+  readonly attribute unrestricted double? desiredSize;
+
+  void close();
+  void enqueue(ArrayBufferView chunk);
+  void error(optional any e);
+};
+
+[Exposed=(Window,Worker,Worklet)]
+interface ReadableStreamBYOBRequest {
+  readonly attribute ArrayBufferView? view;
+
+  void respond([EnforceRange] unsigned long long bytesWritten);
+  void respondWithNewView(ArrayBufferView view);
+};
+
+[Exposed=(Window,Worker,Worklet)]
+interface WritableStream {
+  constructor(optional object underlyingSink, optional QueuingStrategy strategy = {});
+
+  readonly attribute boolean locked;
+
+  Promise<void> abort(optional any reason);
+  Promise<void> close();
+  WritableStreamDefaultWriter getWriter();
+};
+
+dictionary UnderlyingSink {
+  UnderlyingSinkStartCallback start;
+  UnderlyingSinkWriteCallback write;
+  UnderlyingSinkCloseCallback close;
+  UnderlyingSinkAbortCallback abort;
+  any type;
+};
+
+callback UnderlyingSinkStartCallback = any (WritableStreamDefaultController controller);
+callback UnderlyingSinkWriteCallback = Promise<void> (WritableStreamDefaultController controller, optional any chunk);
+callback UnderlyingSinkCloseCallback = Promise<void> ();
+callback UnderlyingSinkAbortCallback = Promise<void> (optional any reason);
+
+[Exposed=(Window,Worker,Worklet)]
+interface WritableStreamDefaultWriter {
+  constructor(WritableStream stream);
+
+  readonly attribute Promise<void> closed;
+  readonly attribute unrestricted double? desiredSize;
+  readonly attribute Promise<void> ready;
+
+  Promise<void> abort(optional any reason);
+  Promise<void> close();
+  void releaseLock();
+  Promise<void> write(optional any chunk);
+};
+
+[Exposed=(Window,Worker,Worklet)]
+interface WritableStreamDefaultController {
+  void error(optional any e);
+};
+
+[Exposed=(Window,Worker,Worklet)]
+interface TransformStream {
+  constructor(optional object transformer,
+              optional QueuingStrategy writableStrategy = {},
+              optional QueuingStrategy readableStrategy = {});
+
+  readonly attribute ReadableStream readable;
+  readonly attribute WritableStream writable;
+};
+
+dictionary Transformer {
+  TransformerStartCallback start;
+  TransformerTransformCallback transform;
+  TransformerFlushCallback flush;
+  any readableType;
+  any writableType;
+};
+
+callback TransformerStartCallback = any (TransformStreamDefaultController controller);
+callback TransformerFlushCallback = Promise<void> (TransformStreamDefaultController controller);
+callback TransformerTransformCallback = Promise<void> (TransformStreamDefaultController controller, optional any chunk);
+
+[Exposed=(Window,Worker,Worklet)]
+interface TransformStreamDefaultController {
+  readonly attribute unrestricted double? desiredSize;
+
+  void enqueue(optional any chunk);
+  void error(optional any reason);
+  void terminate();
+};
+
+dictionary QueuingStrategy {
+  unrestricted double highWaterMark;
+  QueuingStrategySize size;
+};
+
+callback QueuingStrategySize = unrestricted double (optional any chunk);
+
+dictionary QueuingStrategyInit {
+  required unrestricted double highWaterMark;
+};
+
+[Exposed=(Window,Worker,Worklet)]
+interface ByteLengthQueuingStrategy {
+  constructor(QueuingStrategyInit init);
+
+  readonly attribute unrestricted double highWaterMark;
+  readonly attribute Function size;
+};
+
+[Exposed=(Window,Worker,Worklet)]
+interface CountQueuingStrategy {
+  constructor(QueuingStrategyInit init);
+
+  readonly attribute unrestricted double highWaterMark;
+  readonly attribute Function size;
+};

--- a/tests/webidl.rs
+++ b/tests/webidl.rs
@@ -37,6 +37,14 @@ fn should_parse_mediacapture_streams_webidl() {
 }
 
 #[test]
+fn should_parse_streams_webidl() {
+    let content = read_file("./tests/defs/streams.webidl");
+    let parsed = weedle::parse(&content).unwrap();
+
+    assert_eq!(parsed.len(), 37);
+}
+
+#[test]
 fn interface_constructor() {
     let content = read_file("./tests/defs/interface-constructor.webidl");
     let mut parsed = weedle::parse(&content).unwrap();


### PR DESCRIPTION
The WebIDL specification has recently been extended with [async iterable declarations](https://heycam.github.io/webidl/#idl-async-iterable) on interfaces:
```
interface interface_identifier {
  async iterable<value_type>;
  async iterable<value_type>(/* arguments... */);
  async iterable<key_type, value_type>;
  async iterable<key_type, value_type>(/* arguments... */);
};
```
Currently, the [streams specification](https://streams.spec.whatwg.org/#rs-class-definition) is using this in its `ReadableStream` definition:
```
[Exposed=(Window,Worker,Worklet)]
interface ReadableStream {
  // ...

  async iterable<any>(optional ReadableStreamIteratorOptions options = {});
};
```
This PR adds support for parsing such declarations, and adds the current streams WebIDL definitions as a test case.