### PR TITLE
Allows strings in ext attr value list

### DIFF
--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -6,7 +6,7 @@ use crate::literal::StringLit;
 pub type ExtendedAttributeList<'a> = Bracketed<Punctuated<ExtendedAttribute<'a>, term!(,)>>;
 
 /// Matches comma separated identifier list
-pub type IdentifierList<'a> = Punctuated<Identifier<'a>, term!(,)>;
+pub type IdentifierList<'a> = Punctuated<IdentifierOrString<'a>, term!(,)>;
 
 ast_types! {
     /// Parses on of the forms of attribute


### PR DESCRIPTION
Fixes #38 - Unable to parse extended attribute with quoted tuple of values

This may only be a chrome IDL issue since the official WebIDL grammar (https://heycam.github.io/webidl/#es-extended-attributes) only seems to support identifier lists, not string lists. Feel free to ignore/close this PR if this is indeed the case.

I can understand wanting to keep this library strictly in-line with the official grammar.