### PR TITLE
Bump to 0.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weedle"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Sharad Chand <sharad.d.chand@gmail.com>"]
 description = "A WebIDL Parser"
 license = "MIT"


### PR DESCRIPTION
Bump the version to 0.12.0 so we can have a new release which contains the changes from #37 and #43.

Could the release be tagged after merging too?