### PR TITLE
Allow any type as the key type in records

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -120,15 +120,15 @@ ast_types! {
     /// Parses `record<StringType, Type>`
     struct RecordType<'a> {
         record: term!(record),
-        generics: Generics<(StringType, term!(,), Box<Type<'a>>)>,
+        generics: Generics<(Box<RecordKeyType<'a>>, term!(,), Box<Type<'a>>)>,
     }
 
-    /// Parses one of the string types `ByteString|DOMString|USVString`
-    #[derive(Copy)]
-    enum StringType {
+    /// Parses one of the string types `ByteString|DOMString|USVString` or any other type.
+    enum RecordKeyType<'a> {
         Byte(term!(ByteString)),
         DOM(term!(DOMString)),
         USV(term!(USVString)),
+        NonAny(NonAnyType<'a>),
     }
 
     /// Parses one of the member of a union type
@@ -242,7 +242,7 @@ mod test {
     );
 
     test_variants!(
-        StringType {
+        RecordKeyType {
             DOM == "DOMString",
             USV == "USVString",
             Byte == "ByteString"
@@ -250,6 +250,11 @@ mod test {
     );
 
     test!(should_parse_record_type { "record<DOMString, short>" =>
+        "";
+        RecordType;
+    });
+
+    test!(should_parse_record_type_alt_types { "record<u64, short>" =>
         "";
         RecordType;
     });


### PR DESCRIPTION
Over at mozilla/uniffi-rs we use Weedle to parse UDL, which really is just WebIDL with a couple more annotations.
Weedle supports most things we need already.

But this PR here is one thing we might want to have: non-string keys for records.
It seemed easy enough to allow _any_ type by just nesting the parsers (of course for our usecase we will need to restrict that again because keys still need to be hashable ultimately).

Would you consider this change for Weedle?