### PR TITLE
Implemented parsing of ExtendedAttributeWildcard

### DIFF
--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -43,6 +43,13 @@ ast_types! {
             assign: term!(=),
             rhs: IdentifierOrString<'a>,
         }),
+        /// Parses an attribute with a wildcard. Ex: `Exposed=*`
+        #[derive(Copy)]
+        Wildcard(struct ExtendedAttributeWildCard<'a> {
+            lhs_identifier: Identifier<'a>,
+            assign: term!(=),
+            rhs: term!(*),
+        }),
         /// Parses a plain attribute. Ex: `Replaceable`
         #[derive(Copy)]
         NoArgs(struct ExtendedAttributeNoArgs<'a>(

--- a/src/term.rs
+++ b/src/term.rs
@@ -99,7 +99,10 @@ generate_terms! {
     GreaterThan => ">",
 
     /// Represents the terminal symbol `?`
-    QMark => "?"
+    QMark => "?",
+
+    /// Represents the asterisk symbol `*`
+    Asterisk => "*"
 }
 
 generate_terms_for_names! {
@@ -357,6 +360,9 @@ macro_rules! term {
     };
     (?) => {
         $crate::term::QMark
+    };
+    (*) => {
+        $crate::term::Asterisk
     };
     (or) => {
         $crate::term::Or
@@ -629,6 +635,7 @@ mod test {
         assign, Assign, "=";
         greaterthan, GreaterThan, ">";
         qmark, QMark, "?";
+        asterisk, Asterisk, "*";
         or, Or, "or";
         optional, Optional, "optional";
         async_, Async, "async";


### PR DESCRIPTION
This implements the correct parsing of extended attributes of the form `Exposed=*`, a.k.a., [wildcard attributes](https://webidl.spec.whatwg.org/#prod-ExtendedAttributeWildcard). Previously, WebIDL with this syntax would cause a parsing error.

This PR unblocks https://github.com/rustwasm/wasm-bindgen/pull/3046 , which pulls in [an interface](https://streams.spec.whatwg.org/#rs-class-definition) with a wildcard extended attribute.

cc @alexcrichton 