### PR TITLE
Parse `(ULong|Double)Range` types

### DIFF
--- a/src/term.rs
+++ b/src/term.rs
@@ -250,6 +250,12 @@ generate_terms_for_names! {
     /// Represents the terminal symbol `record`
     Record => "record",
 
+    /// Represents the terminal symbol `ULongRange`
+    ULongRange => "ULongRange",
+
+    /// Represents the terminal symbol `DoubleRange`
+    DoubleRange => "DoubleRange",
+
     /// Represents the terminal symbol `ArrayBuffer`
     ArrayBuffer => "ArrayBuffer",
 
@@ -508,6 +514,12 @@ macro_rules! term {
     (record) => {
         $crate::term::Record
     };
+    (ULongRange) => {
+        $crate::term::ULongRange
+    };
+    (DoubleRange) => {
+        $crate::term::DoubleRange
+    };
     (ArrayBuffer) => {
         $crate::term::ArrayBuffer
     };
@@ -684,6 +696,8 @@ mod test {
         unsigned, Unsigned, "unsigned";
         undefined, Undefined, "undefined";
         record, Record, "record";
+        ulongrange, ULongRange, "ULongRange";
+        doublerange, DoubleRange, "DoubleRange";
         arraybuffer, ArrayBuffer, "ArrayBuffer";
         dataview, DataView, "DataView";
         int8array, Int8Array, "Int8Array";

--- a/src/types.rs
+++ b/src/types.rs
@@ -25,6 +25,7 @@ ast_types! {
         Boolean(MayBeNull<term!(boolean)>),
         Byte(MayBeNull<term!(byte)>),
         Octet(MayBeNull<term!(octet)>),
+        Range(MayBeNull<RangeType>),
         ByteString(MayBeNull<term!(ByteString)>),
         DOMString(MayBeNull<term!(DOMString)>),
         USVString(MayBeNull<term!(USVString)>),
@@ -115,6 +116,13 @@ ast_types! {
             unrestricted: Option<term!(unrestricted)>,
             double: term!(double),
         }),
+    }
+
+    /// Parses `(ULong|Double)Range`
+    #[derive(Copy)]
+    enum RangeType {
+        ULong(term!(ULongRange)),
+        Double(term!(DoubleRange)),
     }
 
     /// Parses `record<StringType, Type>`
@@ -296,6 +304,13 @@ mod test {
             Short == "short",
             Long == "long",
             LongLong == "long long"
+        }
+    );
+
+    test_variants!(
+        RangeType {
+            ULong == "ULongRange",
+            Double == "DoubleRange"
         }
     );
 


### PR DESCRIPTION
Heya, this PR adds the `ULongRange` and `DoubleRange` types that are used e.g. in the WebIDL definition for `MediaTrackCapabilities`: https://www.w3.org/TR/mediacapture-streams/#webidl-1135231111.