### PR TITLE
Parse `ObservableArray<type>`

### DIFF
--- a/src/term.rs
+++ b/src/term.rs
@@ -193,6 +193,9 @@ generate_terms_for_names! {
     /// Represents the terminal symbol `FrozenArray`
     FrozenArray => "FrozenArray",
 
+    /// Represents the terminal symbol `ObservableArray`
+    ObservableArray => "ObservableArray",
+
     /// Represents the terminal symbol `Infinity`
     Infinity => "Infinity",
 
@@ -451,6 +454,9 @@ macro_rules! term {
     (FrozenArray) => {
         $crate::term::FrozenArray
     };
+    (ObservableArray) => {
+        $crate::term::ObservableArray
+    };
     (Infinity) => {
         $crate::term::Infinity
     };
@@ -665,6 +671,7 @@ mod test {
         bytestring, ByteString, "ByteString";
         domstring, DOMString, "DOMString";
         frozenarray, FrozenArray, "FrozenArray";
+        observablearray, ObservableArray, "ObservableArray";
         infinity, Infinity, "Infinity";
         nan, NaN, "NaN";
         usvstring, USVString, "USVString";

--- a/src/types.rs
+++ b/src/types.rs
@@ -46,6 +46,7 @@ ast_types! {
         ArrayBufferView(MayBeNull<term!(ArrayBufferView)>),
         BufferSource(MayBeNull<term!(BufferSource)>),
         FrozenArrayType(MayBeNull<FrozenArrayType<'a>>),
+        ObservableArrayType(MayBeNull<ObservableArrayType<'a>>),
         RecordType(MayBeNull<RecordType<'a>>),
         Identifier(MayBeNull<Identifier<'a>>),
     }
@@ -59,6 +60,12 @@ ast_types! {
     /// Parses `FrozenArray<Type>`
     struct FrozenArrayType<'a> {
         frozen_array: term!(FrozenArray),
+        generics: Generics<Box<Type<'a>>>,
+    }
+
+    /// Parses `ObservableArray<Type>`
+    struct ObservableArrayType<'a> {
+        observable_array: term!(ObservableArray),
         generics: Generics<Box<Type<'a>>>,
     }
 
@@ -229,6 +236,7 @@ mod test {
             ArrayBufferView == "ArrayBufferView",
             BufferSource == "BufferSource",
             FrozenArrayType == "FrozenArray<short>",
+            ObservableArrayType == "ObservableArray<short>",
             RecordType == "record<DOMString, short>",
             Identifier == "mango"
         }
@@ -307,6 +315,11 @@ mod test {
     test!(should_parse_frozen_array_type { "FrozenArray<short>" =>
         "";
         FrozenArrayType;
+    });
+
+    test!(should_parse_observable_array_type { "ObservableArray<short>" =>
+        "";
+        ObservableArrayType;
     });
 
     test!(should_parse_sequence_type { "sequence<short>" =>


### PR DESCRIPTION
References:
* https://github.com/w3ctag/design-reviews/issues/693
* https://chromestatus.com/feature/5638996492288000
* https://webidl.spec.whatwg.org/#idl-observable-array
* https://drafts.csswg.org/cssom/#extensions-to-the-document-or-shadow-root-interface

---

Blocker for adding the `adoptedStyleSheets` method over in `web-sys`.